### PR TITLE
documentation: install `texlive`

### DIFF
--- a/requirements/requirements.system.txt
+++ b/requirements/requirements.system.txt
@@ -11,4 +11,4 @@ git
 make
 
 # Documentation.
-texlive-base
+texlive


### PR DESCRIPTION
in place of `texlive-base`. To have bibtex 📚 