### PR TITLE
ExecutionSpace: with/without exec forwarding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ target_sources(
             kokkos-execution/execution_space/then.hpp
             kokkos-execution/impl/bulk.hpp
             kokkos-execution/impl/completion_signatures.hpp
+            kokkos-execution/impl/continues_on.hpp
             kokkos-execution/impl/env.hpp
             kokkos-execution/impl/sync_wait.hpp
             kokkos-execution/utils/ignore_warnings.hpp

--- a/kokkos-execution/execution_space/continues_on.hpp
+++ b/kokkos-execution/execution_space/continues_on.hpp
@@ -1,18 +1,25 @@
 #ifndef KOKKOS_EXECUTION_EXECUTION_SPACE_CONTINUES_ON_HPP
 #define KOKKOS_EXECUTION_EXECUTION_SPACE_CONTINUES_ON_HPP
 
-#include "stdexec/execution.hpp"
+#include "kokkos-execution/utils/ignore_warnings.hpp"
+PRAGMA_DIAGNOSTIC_PUSH
+KOKKOS_EXECUTION_STDEXEC_PRAGMA_DIAGNOSTIC_IGNORED
+#include "exec/env.hpp"
+PRAGMA_DIAGNOSTIC_POP
 
 #include "kokkos-execution/execution_space/execution_space_fwd.hpp"
-
 #include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
+#include "kokkos-execution/impl/continues_on.hpp"
 #include "kokkos-execution/impl/env.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
+struct FwdWithExec { };
+struct FwdWithoutExec { };
+
 //! Receiver for @c continues_on.
-template <stdexec::receiver Rcvr>
+template <stdexec::receiver Rcvr, typename FwdPolicy = FwdWithExec>
 struct ContinuesOnReceiver {
     using receiver_concept = stdexec::receiver_t;
 
@@ -31,7 +38,22 @@ struct ContinuesOnReceiver {
         stdexec::set_stopped(std::move(rcvr));
     }
 
-    KOKKOS_EXECUTION_FORWARDING_GET_ENV(Rcvr, rcvr)
+    [[nodiscard]]
+    constexpr auto get_env() const noexcept -> std::conditional_t<
+        std::same_as<FwdPolicy, FwdWithoutExec>,
+        stdexec::__call_result_t<
+            experimental::execution::__envs::__without_t,
+            stdexec::__fwd_env_t<stdexec::env_of_t<Rcvr>>,
+            get_exec_t
+        >,
+        stdexec::__fwd_env_t<stdexec::env_of_t<Rcvr>>
+    > {
+        if constexpr (std::same_as<FwdPolicy, FwdWithoutExec>) {
+            return experimental::execution::without(stdexec::__fwd_env(stdexec::get_env(rcvr)), get_exec);
+        } else {
+            return stdexec::__fwd_env(stdexec::get_env(rcvr));
+        }
+    }
 };
 
 //! Sender for @c continues_on.
@@ -43,10 +65,32 @@ struct ContinuesOnSender {
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender)
 
-    template <stdexec::receiver Rcvr>
+    template <
+        stdexec::receiver Rcvr,
+        typename FwdPolicy = std::conditional_t<
+            std::same_as<
+                stdexec::__detail::__completing_domain_t<stdexec::set_value_t, Sndr, stdexec::env_of_t<Rcvr>>,
+                Domain
+            >
+                || has_when_all_child_with_at_least_one_child_completing_on_v<
+                    stdexec::set_value_t,
+                    Domain,
+                    Sndr,
+                    stdexec::env_of_t<Rcvr>
+                >
+                || has_fork_join_child_with_at_least_one_child_completing_on_v<
+                    stdexec::set_value_t,
+                    Domain,
+                    Sndr,
+                    stdexec::env_of_t<Rcvr>
+                >,
+            FwdWithExec,
+            FwdWithoutExec
+        >
+    >
     auto connect(Rcvr rcvr) && noexcept(std::is_nothrow_move_constructible_v<Rcvr>)
-        -> stdexec::connect_result_t<Sndr, ContinuesOnReceiver<Rcvr>> {
-        using recv_t = ContinuesOnReceiver<Rcvr>;
+        -> stdexec::connect_result_t<Sndr, ContinuesOnReceiver<Rcvr, FwdPolicy>> {
+        using recv_t = ContinuesOnReceiver<Rcvr, FwdPolicy>;
 
         return stdexec::connect(std::forward<Sndr>(sndr), recv_t{.rcvr = std::move(rcvr)});
     }

--- a/kokkos-execution/impl/continues_on.hpp
+++ b/kokkos-execution/impl/continues_on.hpp
@@ -1,0 +1,81 @@
+#ifndef KOKKOS_EXECUTION_IMPL_CONTINUES_ON_HPP
+#define KOKKOS_EXECUTION_IMPL_CONTINUES_ON_HPP
+
+#include "kokkos-execution/utils/ignore_warnings.hpp"
+PRAGMA_DIAGNOSTIC_PUSH
+KOKKOS_EXECUTION_STDEXEC_PRAGMA_DIAGNOSTIC_IGNORED
+#include "exec/fork_join.hpp"
+PRAGMA_DIAGNOSTIC_POP
+
+namespace Kokkos::Execution::ExecutionSpaceImpl {
+
+//! Determine if at least one of the children of the sender completes on the given domain.
+template <typename ChannelTag, typename DomainType, typename Sndr, typename Env>
+struct has_at_least_one_child_completing_on {
+    template <typename T>
+    using completes_on_domain =
+        std::bool_constant<std::same_as<DomainType, stdexec::__detail::__completing_domain_t<ChannelTag, T, Env>>>;
+
+   public:
+    static constexpr bool value =
+        stdexec::__mapply<stdexec::__many_of<stdexec::__q<completes_on_domain>>, stdexec::__children_of<Sndr>>::value;
+};
+
+//! Check that a sender has a single child with a given tag.
+template <typename Sndr, typename Tag>
+concept has_single_child_with_tag = requires {
+    requires stdexec::__nbr_children_of<Sndr> == 1;
+    typename stdexec::tag_of_t<stdexec::__child_of<Sndr>>;
+    requires std::same_as<stdexec::tag_of_t<stdexec::__child_of<Sndr>>, Tag>;
+};
+
+//! Determine if the sender has a single @c stdexec::when_all child, that has at least one branch completing on the given domain.
+template <typename ChannelTag, typename DomainType, typename Sndr, typename Env>
+struct has_when_all_child_with_at_least_one_child_completing_on {
+    static constexpr bool value = false;
+};
+
+template <typename ChannelTag, typename DomainType, has_single_child_with_tag<stdexec::when_all_t> Sndr, typename Env>
+struct has_when_all_child_with_at_least_one_child_completing_on<ChannelTag, DomainType, Sndr, Env> {
+   private:
+    using child_t = stdexec::__child_of<Sndr>;
+
+   public:
+    static constexpr bool value = has_at_least_one_child_completing_on<ChannelTag, DomainType, child_t, Env>::value;
+};
+
+template <typename ChannelTag, typename DomainType, typename Sndr, typename Env>
+inline constexpr bool has_when_all_child_with_at_least_one_child_completing_on_v =
+    has_when_all_child_with_at_least_one_child_completing_on<ChannelTag, Domain, Sndr, Env>::value;
+
+//! Determine if the sender has a single @c exec::fork_join child, that has at least one branch completing on the given domain.
+template <typename ChannelTag, typename DomainType, typename Sndr, typename Env>
+struct has_fork_join_child_with_at_least_one_child_completing_on {
+    static constexpr bool value = false;
+};
+
+template <typename ChannelTag, typename DomainType, has_single_child_with_tag<exec::fork_join_t> Sndr, typename Env>
+struct has_fork_join_child_with_at_least_one_child_completing_on<ChannelTag, DomainType, Sndr, Env> {
+    using child_t = stdexec::__child_of<Sndr>;
+
+    static consteval bool check() noexcept {
+        using _closures_t = stdexec::__data_of<child_t>;
+        using _child_sndr_t = stdexec::__child_of<child_t>;
+        using _domain_t = stdexec::__completion_domain_of_t<ChannelTag, _child_sndr_t, Env>;
+        using _child_t = stdexec::__copy_cvref_t<child_t, _child_sndr_t>;
+        using _child_completions_t = stdexec::__completion_signatures_of_t<_child_t, stdexec::__fwd_env_t<Env>>;
+        using _sndr_t = exec::fork_join_impl_t::_when_all_sndr_t<_child_completions_t, _closures_t, _domain_t>;
+        return has_at_least_one_child_completing_on<ChannelTag, DomainType, _sndr_t, Env>::value;
+    }
+
+   public:
+    static constexpr bool value = check();
+};
+
+template <typename ChannelTag, typename DomainType, typename Sndr, typename Env>
+inline constexpr bool has_fork_join_child_with_at_least_one_child_completing_on_v =
+    has_fork_join_child_with_at_least_one_child_completing_on<ChannelTag, DomainType, Sndr, Env>::value;
+
+} // namespace Kokkos::Execution::ExecutionSpaceImpl
+
+#endif // KOKKOS_EXECUTION_IMPL_CONTINUES_ON_HPP

--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -93,8 +93,6 @@ TEST_F(WhenAllTest, single_branch_followed_by_self) {
 /**
  * @test A @c stdexec::when_all with a single @ref Kokkos::Execution::ExecutionSpaceContext branch,
  *       followed by some work on some unrelated scheduler, followed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
- *
- * @todo It misses a synchronization after the branch on @ref Kokkos::Execution::ExecutionSpaceContext.
  */
 TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
@@ -110,6 +108,7 @@ TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
         recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
             MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 
@@ -195,8 +194,6 @@ TEST_F(WhenAllTest, two_branches_followed_by_self) {
  * @test A @c stdexec::when_all with two branches, one on @ref Kokkos::Execution::ExecutionSpaceContext and another
  *       on the single thread context,
  *       followed by the single thread context, follwed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
- *
- * @todo It misses a synchronization after the branch on @ref Kokkos::Execution::ExecutionSpaceContext.
  */
 TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
     const view_s_t data(Kokkos::view_alloc("data - shared space"));
@@ -214,6 +211,7 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
         recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
             MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 


### PR DESCRIPTION
We want to keep the places where we can introspect the chain to avoid unnecessary fences.

The first approach was to instruct our `continues_on` to use `exec::without` to remove the `get_exec` query from the environment if the upstream isn't completing on our domain .

But this "completion domain" check alone breaks the primary reason for the `get_exec` forwarding query that is to try pass through `when_all` or `fork_join` to avoid fences.

So the second step is to do very intrusive sender introspection, and for `when_all` or `fork_join` we check if at least one branch completes on our domain, in which case we still forward the `get_exec` query.