### PR TITLE
ExecutionSpace: one more `when_all` case

### DIFF
--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -8,6 +8,7 @@ PRAGMA_DIAGNOSTIC_POP
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
 #include "tests/utils/callback_matchers.hpp"
+#include "tests/utils/check_rcvr_env_queryable_with.hpp"
 #include "tests/utils/execution_space_context.hpp"
 #include "tests/utils/functors/increment.hpp"
 #include "tests/utils/functors/labeled.hpp"
@@ -41,7 +42,13 @@ class WhenAllTest
     using recorder_listener_t = RecorderListener<BeginFenceEvent, BeginParallelForEvent>;
 };
 
-//! @test A @c stdexec::when_all with a single @ref Kokkos::Execution::ExecutionSpaceContext branch.
+/**
+ * @test A @c stdexec::when_all with a single branch on @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then -- when_all --> sync_wait
+ * @endverbatim
+ */
 TEST_F(WhenAllTest, single_branch) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
 
@@ -72,8 +79,12 @@ TEST_F(WhenAllTest, single_branch) {
 }
 
 /**
- * @test A @c stdexec::when_all with a single @ref Kokkos::Execution::ExecutionSpaceContext branch,
- *       followed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
+ * @test A @c stdexec::when_all with a single branch on @ref Kokkos::Execution::ExecutionSpaceContext,
+ *       followed by work on the same @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then -- when_all --> continues_on(esc) | then
+ * @endverbatim
  */
 TEST_F(WhenAllTest, single_branch_followed_by_self) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
@@ -96,8 +107,13 @@ TEST_F(WhenAllTest, single_branch_followed_by_self) {
 }
 
 /**
- * @test A @c stdexec::when_all with a single mixed branch involving a segment on a @ref Kokkos::Execution::ExecutionSpaceContext instance
- *       followed by a segment on another scheduler. The @c stdexec::when_all is followed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
+ * @test A @c stdexec::when_all with a single branch with a segment on @ref Kokkos::Execution::ExecutionSpaceContext
+ *       followed by a segment on another context. The @c stdexec::when_all is followed by work on the same
+ *       @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then --> continues_on(stc) | then -- when_all --> continues_on(esc) | then
+ * @endverbatim
  */
 TEST_F(WhenAllTest, single_mixed_branch_followed_by_self) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
@@ -124,8 +140,12 @@ TEST_F(WhenAllTest, single_mixed_branch_followed_by_self) {
 }
 
 /**
- * @test A @c stdexec::when_all with a single @ref Kokkos::Execution::ExecutionSpaceContext branch,
- *       followed by some work on some unrelated scheduler, followed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
+ * @test A @c stdexec::when_all with a single branch on @ref Kokkos::Execution::ExecutionSpaceContext, followed by work
+ *       on another context, followed by work on the same @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then -- when_all --> continues_on(stc) | then --> continues_on(esc) | then
+ * @endverbatim
  */
 TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
@@ -151,9 +171,14 @@ TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
 }
 
 /**
- * @test A @c stdexec::when_all with two branches, one on @ref Kokkos::Execution::ExecutionSpaceContext and another
- *       on the single thread context,
- *       followed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
+ * @test A @c stdexec::when_all with two branches, the first on @ref Kokkos::Execution::ExecutionSpaceContext and the second
+ *       on another context, followed by work on the same @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then_atomic -- \
+ *                                 when_all --> continues_on(esc) | then
+ * schedule(stc) | then_atomic -- /
+ * @endverbatim
  */
 TEST_F(WhenAllTest, two_mixed_branches_followed_by_self) {
     const view_s_t data(Kokkos::view_alloc("data - shared space"));
@@ -186,9 +211,14 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_self) {
 }
 
 /**
- * @test A @c stdexec::when_all with two branches, one on some @ref Kokkos::Execution::ExecutionSpaceContext instance A and another
- *       on another @ref Kokkos::Execution::ExecutionSpaceContext instance B,
- *       followed by the @ref Kokkos::Execution::ExecutionSpaceContext instance A.
+ * @test A @c stdexec::when_all with two branches, the first on @ref Kokkos::Execution::ExecutionSpaceContext instance A
+ *       and the second on @ref Kokkos::Execution::ExecutionSpaceContext instance B, followed by work on instance A.
+ *
+ * @verbatim
+ * schedule(esc_A) | then_atomic -- \
+ *                                   when_all --> continues_on(esc_A) | then
+ * schedule(esc_B) | then_atomic -- /
+ * @endverbatim
  */
 TEST_F(WhenAllTest, two_branches_followed_by_self) {
     const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
@@ -230,9 +260,15 @@ TEST_F(WhenAllTest, two_branches_followed_by_self) {
 }
 
 /**
- * @test A @c stdexec::when_all with two branches, one on @ref Kokkos::Execution::ExecutionSpaceContext and another
- *       on the single thread context,
- *       followed by the single thread context, follwed by the same @ref Kokkos::Execution::ExecutionSpaceContext instance.
+ * @test A @c stdexec::when_all with two branches, the first on @ref Kokkos::Execution::ExecutionSpaceContext
+ *       and the second on another context, followed by work on the same other context, followed by work
+ *       on the same @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then_atomic -- \
+ *                                 when_all --> continues_on(stc) | then --> continues_on(esc) | then
+ * schedule(stc) | then_atomic -- /
+ * @endverbatim
  */
 TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
     const view_s_t data(Kokkos::view_alloc("data - shared space"));
@@ -260,6 +296,46 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
 }
 
 /**
+ * @test A nested @c stdexec::when_all. There are two branches. The first branch is on @ref Kokkos::Execution::ExecutionSpaceContext.
+ *       The second branch is itself a @c stdexec::when_all with a single branch with a segment on the same @ref Kokkos::Execution::ExecutionSpaceContext
+ *       instance, followed by work on another context.
+ *
+ * @todo There is a missing fence. Our @c stdexec::continues_on puts the execution space instance in the environment
+ *       because its preceding @c stdexec::when_all has at least one branch on @ref Kokkos::Execution::ExecutionSpaceContext.
+ *
+ * @verbatim
+ * schedule(esc) | then_atomic -------------------------------------------------- \
+ *                                                                                 when_all --> continues_on(esc) | then
+ * schedule(esc) | then_atomic -- when_all --> continues_on(stc) | then_atomic -- /
+ * @endverbatim
+ */
+TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
+    const view_s_t data(Kokkos::view_alloc("data - shared space"));
+
+    const context_t esc{exec};
+    experimental::execution::single_thread_context stc{};
+
+    auto sndr =
+        stdexec::when_all(
+            stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
+            stdexec::when_all(stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
+                | Tests::Utils::check_rcvr_env_queryable_with<Kokkos::Execution::ExecutionSpaceImpl::get_exec_t>()
+                | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
+        | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
+
+    ASSERT_THAT(
+        recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
+        testing::ElementsAre(
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            // MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+
+    ASSERT_EQ(data(), 4);
+}
+
+/**
  * @test Verify that an independent branch can overlap with a nested @c stdexec::when_all.
  *
  * @verbatim
@@ -273,8 +349,6 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
  * @todo C cannot currently overlap with either of A, B or D.
  */
 TEST_F(WhenAllTest, nested_when_all_with_independent_branch) {
-    const view_s_t data(Kokkos::view_alloc("data - shared space"));
-
     const auto [exec_A, exec_B, exec_C] = Kokkos::Experimental::partition_space(exec, 1, 1, 1);
 
     const context_t esc_A{exec_A}, esc_B{exec_B}, esc_C{exec_C};

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_one_test(NAME check_scheduler_type)
+add_one_test(NAME check_rcvr_env_queryable_with)

--- a/tests/utils/check_rcvr_env_queryable_with.hpp
+++ b/tests/utils/check_rcvr_env_queryable_with.hpp
@@ -1,0 +1,82 @@
+#ifndef KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_QUERYABLE_WITH_HPP
+#define KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_QUERYABLE_WITH_HPP
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "kokkos-execution/impl/attributes.hpp"
+#include "kokkos-execution/impl/completion_signatures.hpp"
+#include "kokkos-execution/impl/env.hpp"
+
+#include "tests/utils/stdexec.hpp"
+
+/**
+ * @file
+ *
+ * Check the environment of the receiver is queryable for a given set of queries.
+ */
+
+namespace Tests::Utils {
+
+template <bool IsQueryable, stdexec::sender Sndr, typename... Queries>
+struct CheckRcvrEnvQueryableWithSender;
+
+template <bool IsQueryable, typename... Queries>
+struct check_rcvr_env_queryable_with_t {
+    [[nodiscard]]
+    constexpr auto operator()() const noexcept {
+        return stdexec::__closure(*this);
+    }
+
+    template <stdexec::sender Sndr>
+    [[nodiscard]]
+    constexpr auto operator()(Sndr&& sndr) const {
+        return CheckRcvrEnvQueryableWithSender<IsQueryable, Sndr, Queries...>{std::forward<Sndr>(sndr)};
+    }
+};
+
+template <bool IsQueryable, stdexec::sender Sndr, typename... Queries>
+struct CheckRcvrEnvQueryableWithSender {
+    using sender_concept = stdexec::sender_t;
+
+    Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvQueryableWithSender)
+
+    template <stdexec::receiver Rcvr>
+    constexpr auto connect(Rcvr rcvr) && noexcept(stdexec::__nothrow_connectable<Sndr&&, Rcvr&&>) {
+        static_assert(check_rcvr_env<Rcvr>());
+        return stdexec::connect(std::forward<Sndr>(sndr), std::move(rcvr));
+    }
+
+    template <stdexec::receiver Rcvr>
+    constexpr auto connect(Rcvr rcvr) const & noexcept(stdexec::__nothrow_connectable<const Sndr&, Rcvr&&>) {
+        static_assert(check_rcvr_env<Rcvr>());
+        return stdexec::connect(sndr, std::move(rcvr));
+    }
+
+    template <stdexec::receiver Rcvr>
+    static consteval bool check_rcvr_env() {
+        if constexpr (IsQueryable) {
+            static_assert(
+                (stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Queries> && ...),
+                "The receiver environment is not queryable with at least one query from the given set of queries.");
+        } else {
+            static_assert(
+                ((!stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Queries>) && ...),
+                "The receiver environment is queryable with at least one query from the given set of queries.");
+        }
+        return true;
+    }
+
+    KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
+};
+
+template <typename... Queries>
+inline constexpr check_rcvr_env_queryable_with_t<true, Queries...> check_rcvr_env_queryable_with{};
+
+template <typename... Queries>
+inline constexpr check_rcvr_env_queryable_with_t<false, Queries...> check_rcvr_env_not_queryable_with{};
+
+} // namespace Tests::Utils
+
+#endif // KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_QUERYABLE_WITH_HPP

--- a/tests/utils/test_check_rcvr_env_queryable_with.cpp
+++ b/tests/utils/test_check_rcvr_env_queryable_with.cpp
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "tests/utils/check_rcvr_env_queryable_with.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Tests for @c Tests::Utils::check_rcvr_env_queryable_with_t
+ * ----------------------------------------------------------
+ *
+ * This group of tests check the behavior of @ref Tests::Utils::check_rcvr_env_queryable_with and @ref Tests::Utils::check_rcvr_env_not_queryable_with.
+ *
+ * The tests can be found in @ref tests/utils/test_check_rcvr_env_queryable_with.cpp.
+ */
+
+namespace Tests {
+
+constexpr struct PropA : public ::stdexec::__query<PropA> {
+} prop_a{};
+
+struct PropB : public ::stdexec::__query<PropB> { };
+
+/**
+ * @test Write @ref PropA in the environment with @c stdexec::write_env and check that @ref Tests::Utils::check_rcvr_env_queryable_with
+ *       indicates that the environment is queryable with @ref PropA and
+ *       @ref Tests::Utils::check_rcvr_env_not_queryable_with indicates that the environment is not queryable with @ref PropB.
+ */
+TEST(check_rcvr_env_queryable_with, and_not) {
+    auto sndr = stdexec::just() | Tests::Utils::check_rcvr_env_queryable_with<PropA>()
+              | Tests::Utils::check_rcvr_env_not_queryable_with<PropB>()
+              | stdexec::write_env(stdexec::prop{prop_a, 42.});
+
+    stdexec::sync_wait(std::move(sndr)); // NOLINT(performance-move-const-arg)
+}
+
+} // namespace Tests


### PR DESCRIPTION
with a fence that may be missing 😦 