### PR TITLE
feature: use event to allow for overlapping workloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=address"}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=leak"}
-          - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=thread -Wno-error=tsan", env: {OMP_NUM_THREADS: 1}}
+          - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=thread -Wno-error=tsan", env: {OMP_NUM_THREADS: 1}, docker_run_args: "--security-opt seccomp=unconfined", no-aslr: true}
           - kokkos_backends: [OpenMP]
             compiler:
               family: clang
@@ -103,6 +103,7 @@ jobs:
       - run: |
           cmake --build --preset=${{ matrix.compiler.family }}-${{ join(matrix.kokkos_backends, '-') }} -j4
       - run: |
+          ${{ matrix.no-aslr && 'setarch --addr-no-randomize' || '' }} \
           ctest --preset=${{ matrix.compiler.family }}-${{ join(matrix.kokkos_backends, '-') }}
       - run: |
           bash tests/install_test.sh ${{ matrix.compiler.family }} ${{ matrix.compiler.family }}-${{ join(matrix.kokkos_backends, '-') }}

--- a/cmake/KokkosExecutionConfig.cmake.in
+++ b/cmake/KokkosExecutionConfig.cmake.in
@@ -1,5 +1,6 @@
 @PACKAGE_INIT@
 
+set(KokkosExecution_ENABLE_EVENT_DISPATCH @KokkosExecution_ENABLE_EVENT_DISPATCH@)
 set(KokkosExecution_ENABLE_DEBUG_LOGGING @KokkosExecution_ENABLE_DEBUG_LOGGING@)
 
 include(CMakeFindDependencyMacro)
@@ -8,11 +9,19 @@ find_dependency(Kokkos COMPONENTS kokkoscore)
 
 find_dependency(stdexec)
 
+if(KokkosExecution_ENABLE_EVENT_DISPATCH)
+  find_dependency(KokkosUtils)
+endif()
+
 if(KokkosExecution_ENABLE_DEBUG_LOGGING)
   find_dependency(plog)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/KokkosExecutionTargets.cmake")
+
+if(KokkosExecution_ENABLE_EVENT_DISPATCH)
+  target_link_libraries(Kokkos::kokkosexecution INTERFACE Kokkos::kokkosutils)
+endif()
 
 if(KokkosExecution_ENABLE_DEBUG_LOGGING)
   target_link_libraries(Kokkos::kokkosexecution INTERFACE plog::plog)

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -4,7 +4,9 @@
 #include "kokkos-execution/stdexec.hpp"
 
 #include "kokkos-execution/execution_space/get_exec.hpp"
+#include "kokkos-execution/impl/dispatch_label.hpp"
 #include "kokkos-execution/impl/env.hpp"
+#include "kokkos-execution/impl/event.hpp"
 #include "kokkos-execution/impl/sender_concepts.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
@@ -65,44 +67,117 @@ struct RequiresSynchronization {
     }
 };
 
-template <stdexec::receiver Rcvr, Closure Clsr>
-struct OpStateBase : public stdexec::__immovable {
-    using execution_space = typename Clsr::execution_space;
+//! The execution space supports events and the receiver is queryable for a delegation scheduler.
+template <typename Rcvr, typename Exec>
+concept delegate_completion_with_event =
+    Kokkos::Execution::Impl::support_events<Exec>
+    && stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, stdexec::get_delegation_scheduler_t>;
 
+template <
+    stdexec::receiver Rcvr,
+    Kokkos::ExecutionSpace Exec,
+    bool Delegate = delegate_completion_with_event<Rcvr, Exec>
+>
+struct MayDelegateCompletionWithEvent;
+
+template <stdexec::receiver Rcvr, Kokkos::ExecutionSpace Exec>
+struct WaitEventReceiver {
+    using receiver_concept = stdexec::receiver_t;
+    using event_t = Impl::Event<Exec>;
+
+    MayDelegateCompletionWithEvent<Rcvr, Exec>* opstate;
+    event_t event;
+
+    void set_value() && noexcept {
+        try {
+            event.wait();
+            opstate->storage.__destroy();
+            stdexec::set_value(std::move(opstate->rcvr));
+        } catch (...) {
+            opstate->storage.__destroy();
+            stdexec::set_error(std::move(opstate->rcvr), std::current_exception());
+        }
+    }
+};
+
+template <stdexec::receiver Rcvr, Kokkos::ExecutionSpace Exec>
+struct MayDelegateCompletionWithEvent<Rcvr, Exec, false> {
+    static constexpr auto label = Impl::dispatch_label<Exec, ": after dispatch">();
+
+    Rcvr rcvr;
+
+    template <typename OpState>
+    void delegate(OpState* const opstate) noexcept {
+        if (RequiresSynchronization<Rcvr, OpState>{}(*opstate)) {
+            opstate->query(get_exec).get().fence(std::string(label));
+        }
+        stdexec::set_value(std::move(this->rcvr));
+    }
+};
+
+template <stdexec::receiver Rcvr, Kokkos::ExecutionSpace Exec>
+struct MayDelegateCompletionWithEvent<Rcvr, Exec, true> {
+    using receiver_t = WaitEventReceiver<Rcvr, Exec>;
+    using opstate_t = stdexec::connect_result_t<
+        stdexec::schedule_result_t<
+            stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, stdexec::get_delegation_scheduler_t>
+        >,
+        receiver_t
+    >;
+
+    Rcvr rcvr;
+    stdexec::__manual_lifetime<opstate_t> storage{};
+
+    template <typename OpState>
+    void delegate(OpState* const opstate) noexcept {
+        if (RequiresSynchronization<Rcvr, OpState>{}(*opstate)) {
+            storage.__construct_from(
+                stdexec::connect,
+                stdexec::schedule(stdexec::get_delegation_scheduler(stdexec::get_env(this->rcvr))),
+                receiver_t{.opstate = opstate, .event = typename receiver_t::event_t{opstate->query(get_exec).get()}});
+            stdexec::start(storage.__get());
+        } else {
+            stdexec::set_value(std::move(this->rcvr));
+        }
+    }
+};
+
+template <stdexec::receiver Rcvr, Closure Clsr>
+struct OpStateBase
+    : public stdexec::__immovable
+    , public MayDelegateCompletionWithEvent<Rcvr, typename Clsr::execution_space> {
+    using execution_space = typename Clsr::execution_space;
     using receiver_t = Rcvr;
 
-    receiver_t rcvr;
+    using may_delegate_completion_with_event_t = MayDelegateCompletionWithEvent<Rcvr, execution_space>;
+
     Clsr clsr;
 
-    constexpr explicit OpStateBase(Rcvr rcvr_, Clsr clsr_)
-        noexcept(std::is_nothrow_move_constructible_v<Rcvr> && std::is_nothrow_move_constructible_v<Clsr>)
-        : rcvr(std::move(rcvr_))
+    constexpr explicit OpStateBase(Rcvr rcvr_, Clsr clsr_) noexcept(
+        std::is_nothrow_constructible_v<may_delegate_completion_with_event_t, Rcvr>
+        && std::is_nothrow_move_constructible_v<Clsr>)
+        : may_delegate_completion_with_event_t{std::move(rcvr_)}
         , clsr(std::move(clsr_)) {
     }
 
     void propagate_completion_signal(stdexec::set_value_t) noexcept {
         try {
-            clsr.execute();
+            this->clsr.execute();
         } catch (...) {
             this->propagate_completion_signal(stdexec::set_error, std::current_exception());
             return;
         }
 
-        if (RequiresSynchronization<Rcvr, OpStateBase>{}(*this)) {
-            this->query(get_exec)
-                .get()
-                .fence(std::format("{}: continuation", Kokkos::Impl::TypeInfo<execution_space>::name()));
-        }
-        stdexec::set_value(std::move(rcvr));
+        may_delegate_completion_with_event_t::delegate(this);
     }
 
     template <typename Error>
     void propagate_completion_signal(stdexec::set_error_t, Error&& error) noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(error));
+        stdexec::set_error(std::move(this->rcvr), std::forward<Error>(error));
     }
 
     void propagate_completion_signal(stdexec::set_stopped_t) noexcept {
-        stdexec::set_stopped(std::move(rcvr));
+        stdexec::set_stopped(std::move(this->rcvr));
     }
 
     [[nodiscard]]
@@ -110,7 +185,7 @@ struct OpStateBase : public stdexec::__immovable {
         return ExecutionSpaceRef<execution_space>{clsr.get_policy().space()};
     }
 
-    KOKKOS_EXECUTION_FORWARDING_GET_ENV(Rcvr, rcvr)
+    KOKKOS_EXECUTION_FORWARDING_GET_ENV(Rcvr, this->rcvr)
 };
 
 template <typename ParentOp>

--- a/kokkos-execution/impl/HPX/event.hpp
+++ b/kokkos-execution/impl/HPX/event.hpp
@@ -20,7 +20,7 @@ struct SupportEvents<Kokkos::Experimental::HPX> : std::true_type { };
 
 template <>
 struct Event<Kokkos::Experimental::HPX> {
-    std::shared_ptr<hpx::lcos::local::event> m_event = nullptr;
+    mutable std::optional<Kokkos::Experimental::HPX> m_exec = std::nullopt;
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
@@ -32,12 +32,12 @@ struct Event<Kokkos::Experimental::HPX> {
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&& other) noexcept
-        : m_event(std::move(other.m_event))
+        : m_exec(std::move(other.m_exec))
         , m_event_id(std::exchange(other.m_event_id, invalid_event_id)) {
     }
     Event& operator=(Event&& other) noexcept {
         if (this != &other) {
-            m_event = std::move(other.m_event);
+            m_exec = std::move(other.m_exec);
             m_event_id = std::exchange(other.m_event_id, invalid_event_id);
         }
         return *this;
@@ -45,30 +45,39 @@ struct Event<Kokkos::Experimental::HPX> {
     ~Event() = default;
 
     void record(const Kokkos::Experimental::HPX& exec) {
-        /**
-         * Always allocate a new event. Otherwise, the sequence:
-         * @code
-         * event.record(exec_A);
-         * event.record(exec_B);
-         * event.wait();
-         * @endcode
-         * will be surprising to the user. Indeed, if the two successive calls to @ref record
-         * would use the same @ref m_event, the call to @ref wait would potentially complete
-         * due to @c exec_A, while the expectation is that it completes due to @c exec_B.
-         */
-        m_event = std::make_shared<hpx::lcos::local::event>();
-        exec.impl_bulk_plain_erased<int>(
-            false, /* force_synchronous */
-            true,  /* is_light_weight_policy */
-            [event = m_event](const auto) { event->set(); },
-            1);
+        m_exec = exec;
         record_event(exec, m_event_id);
     }
 
+    /**
+     * If there is no explicit call to the @c Kokkos::Experimental::HPX instance @c fence anywhere, there will
+     * be leaks due to circular dependencies, much like described in https://github.com/kokkos/kokkos/pull/8992.
+     *
+     * The initial approach from https://github.com/uliegecsm/kokkos-execution/pull/106, based on using
+     * @c hpx::lcos::local::event, has been discarded because it would never clean the underlying sender through a
+     * @c fence.
+     *
+     * Yet, it has been decided to mimic
+     * https://github.com/kokkos/kokkos/blob/91584fc13aaf09330bc391466dbae0249895291f/core/src/HPX/Kokkos_HPX.hpp#L139-L156
+     * so that there is no @c fence event recorded.
+     *
+     * Even though @ref wait may therefore synchronize even the work pushed to @ref m_exec after the call to @ref record,
+     * it's the most reasonable way forward for now.
+     */
     void wait() const {
         wait_event(m_event_id);
-        if (!m_event->occurred()) {
-            m_event->wait();
+        if (m_exec.has_value()) {
+            auto& instance_data = m_exec->impl_get_instance_data();
+
+            {
+                const std::lock_guard<hpx::spinlock> lock(instance_data.m_sender_mutex);
+
+                auto& sndr = instance_data.m_sender;
+                hpx::this_thread::experimental::sync_wait(std::move(sndr));
+                sndr = hpx::execution::experimental::unique_any_sender<>(hpx::execution::experimental::just());
+            }
+
+            m_exec = std::nullopt;
         }
     }
 };

--- a/tests/execution_space/test_operation_state.cpp
+++ b/tests/execution_space/test_operation_state.cpp
@@ -82,6 +82,49 @@ constexpr bool test_op_state_passed_by_const_ref() {
 }
 static_assert(test_op_state_passed_by_const_ref());
 
+/**
+ * @test Check that @ref Kokkos::Execution::ExecutionSpaceImpl::OpStateBase possibly uses
+ *       an @ref Kokkos::Execution::Impl::Event only if
+ *       the receiver environment is queryable for a delegation scheduler and the execution space supports events.
+ */
+template <stdexec::receiver Rcvr>
+consteval bool test_delegate_completion_with_event() {
+    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+        std::string_view,
+        Tests::Utils::Functors::Labeled<'a'>,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
+    >;
+    using opstate_t =
+        Kokkos::Execution::ExecutionSpaceImpl::OpState<typename OpStateTest::schedule_sender_t, Rcvr, closure_t>;
+    using opstate_base_t = Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<Rcvr, closure_t>;
+    using may_delegate_completion_with_event_t =
+        Kokkos::Execution::ExecutionSpaceImpl::MayDelegateCompletionWithEvent<Rcvr, TEST_EXECUTION_SPACE>;
+
+    static_assert(std::derived_from<opstate_t, opstate_base_t>);
+    static_assert(std::derived_from<opstate_base_t, may_delegate_completion_with_event_t>);
+
+    //! When delegating, additional space is taken by the storage of the operation state. Otherwise, it only stores the receiver.
+    if constexpr (Kokkos::Execution::ExecutionSpaceImpl::delegate_completion_with_event<Rcvr, TEST_EXECUTION_SPACE>) {
+        static_assert(sizeof(may_delegate_completion_with_event_t) > sizeof(Rcvr));
+        static_assert(std::same_as<
+                      typename may_delegate_completion_with_event_t::receiver_t,
+                      Kokkos::Execution::ExecutionSpaceImpl::WaitEventReceiver<Rcvr, TEST_EXECUTION_SPACE>
+        >);
+        static_assert(std::same_as<
+                      typename may_delegate_completion_with_event_t::receiver_t::event_t,
+                      Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE>
+        >);
+    } else {
+        static_assert(sizeof(may_delegate_completion_with_event_t) == sizeof(Rcvr));
+    }
+
+    return true;
+}
+static_assert(test_delegate_completion_with_event<Tests::Utils::SinkReceiver>());
+static_assert(test_delegate_completion_with_event<
+              Kokkos::Execution::ExecutionSpaceImpl::SyncWaitReceiver<TEST_EXECUTION_SPACE>
+>());
+
 //! @test Check construction, query for execution space instance, and start.
 TEST_F(OpStateTest, construct_query_and_start) {
     constexpr size_t size = 10;

--- a/tests/execution_space/test_split.cpp
+++ b/tests/execution_space/test_split.cpp
@@ -5,6 +5,8 @@ KOKKOS_EXECUTION_STDEXEC_PRAGMA_DIAGNOSTIC_IGNORED
 #include "exec/static_thread_pool.hpp"
 PRAGMA_DIAGNOSTIC_POP
 
+#include "kokkos-execution/execution_space.hpp"
+
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
@@ -32,7 +34,12 @@ class SplitTest
     : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>
     , public Kokkos::utils::tests::scoped::callbacks::Manager {
    public:
-    using recorder_listener_t = RecorderListener<BeginFenceEvent, BeginParallelForEvent>;
+    using recorder_listener_t = RecorderListener<
+        BeginFenceEvent,
+        BeginParallelForEvent,
+        Kokkos::Execution::Impl::RecordEvent,
+        Kokkos::Execution::Impl::WaitEvent
+    >;
 };
 
 //! @test Use @c experimental::execution::split and @c stdexec::sync_wait right after.
@@ -72,17 +79,33 @@ TEST_F(SplitTest, within) {
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 
-    /// Each branch may be executed by a distinct host thread. However, the callback manager is not thread safe.
-    /// So ordering of the event is not guaranteed.
-    ASSERT_THAT(
-        recorder_listener_t::record([chain = std::move(chain)]() mutable { stdexec::sync_wait(std::move(chain)); }),
-        testing::UnorderedElementsAre(
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation"))));
+    const auto recorded_events = recorder_listener_t::record(
+        [chain = std::move(chain)]() mutable { stdexec::sync_wait(std::move(chain)); });
+
+    /// Each branch may be executed by a distinct host thread. So ordering of the event is not guaranteed.
+    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_THAT(recorded_events, ::testing::SizeIs(8));
+        ASSERT_THAT(
+            recorded_events, ::testing::Contains(MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then"))).Times(4));
+        ASSERT_THAT(recorded_events, ::testing::Contains(MATCHER_FOR_RECORD_EVENT(exec)).Times(2));
+        std::ranges::for_each(
+            recorded_events | std::views::filter([](const auto& event) -> bool {
+                return std::holds_alternative<Kokkos::Execution::Impl::RecordEvent>(event);
+            }),
+            [&](const auto& event) {
+                ASSERT_THAT(recorded_events, ::testing::Contains(MATCHER_FOR_WAIT_EVENT(event)).Times(1));
+            });
+    } else {
+        ASSERT_THAT(
+            recorded_events,
+            testing::UnorderedElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
+    }
 
     ASSERT_EQ(data(), 5);
 }

--- a/tests/execution_space/test_transfer_when_all.cpp
+++ b/tests/execution_space/test_transfer_when_all.cpp
@@ -4,6 +4,8 @@ KOKKOS_EXECUTION_STDEXEC_PRAGMA_DIAGNOSTIC_IGNORED
 #include "exec/single_thread_context.hpp"
 PRAGMA_DIAGNOSTIC_POP
 
+#include "kokkos-execution/execution_space.hpp"
+
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
@@ -32,7 +34,12 @@ class TransferWhenAllTest
     : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>
     , public Kokkos::utils::tests::scoped::callbacks::Manager {
    public:
-    using recorder_listener_t = RecorderListener<BeginFenceEvent, BeginParallelForEvent>;
+    using recorder_listener_t = RecorderListener<
+        BeginFenceEvent,
+        BeginParallelForEvent,
+        Kokkos::Execution::Impl::RecordEvent,
+        Kokkos::Execution::Impl::WaitEvent
+    >;
 };
 
 //! @test Two branches on different execution space instances A and B of the same type, followed by a @c stdexec::then on instance A.
@@ -75,13 +82,21 @@ TEST_F(TransferWhenAllTest, Y) {
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
+    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 6);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")));
+        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait")));
     } else {
         ASSERT_THAT(
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
     }

--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -7,6 +7,8 @@ PRAGMA_DIAGNOSTIC_POP
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
+#include "kokkos-execution/execution_space.hpp"
+
 #include "tests/utils/callback_matchers.hpp"
 #include "tests/utils/check_rcvr_env_queryable_with.hpp"
 #include "tests/utils/execution_space_context.hpp"
@@ -39,7 +41,12 @@ class WhenAllTest
     : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>
     , public Kokkos::utils::tests::scoped::callbacks::Manager {
    public:
-    using recorder_listener_t = RecorderListener<BeginFenceEvent, BeginParallelForEvent>;
+    using recorder_listener_t = RecorderListener<
+        BeginFenceEvent,
+        BeginParallelForEvent,
+        Kokkos::Execution::Impl::RecordEvent,
+        Kokkos::Execution::Impl::WaitEvent
+    >;
 };
 
 /**
@@ -67,13 +74,23 @@ TEST_F(WhenAllTest, single_branch) {
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 
-    /// Because the sender returned by @c stdexec::when_all is not an execution space completing sender,
-    /// the default implementation of @c stdexec::sync_wait is used.
-    ASSERT_THAT(
-        recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
-        testing::ElementsAre(
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation"))));
+    const auto recorded_events = recorder_listener_t::record(
+        [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
+
+    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 3);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
+    } else {
+        /// Because the sender returned by @c stdexec::when_all is not an execution space completing sender,
+        /// the default implementation of @c stdexec::sync_wait is used.
+        ASSERT_THAT(
+            recorded_events,
+            testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
+    }
 
     ASSERT_EQ(data(), 1);
 }
@@ -159,13 +176,25 @@ TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 
-    ASSERT_THAT(
-        recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
-        testing::ElementsAre(
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    const auto recorded_events = recorder_listener_t::record(
+        [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
+
+    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 5);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+    } else {
+        ASSERT_THAT(
+            recorded_events,
+            testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    }
 
     ASSERT_EQ(data(), 3);
 }
@@ -245,13 +274,21 @@ TEST_F(WhenAllTest, two_branches_followed_by_self) {
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
+    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 6);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait")));
     } else {
         ASSERT_THAT(
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
     }
@@ -298,13 +335,21 @@ TEST_F(WhenAllTest, two_branches_host_device_followed_by_device) {
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    } else if constexpr (Kokkos::Execution::Impl::support_events<host_execution_space>) {
+        ASSERT_EQ(recorded_events.size(), 6);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_h));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
     } else {
         ASSERT_THAT(
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     }
@@ -337,13 +382,25 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 
-    ASSERT_THAT(
-        recorder_listener_t::record([sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); }),
-        testing::ElementsAre(
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
-            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    const auto recorded_events = recorder_listener_t::record(
+        [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
+
+    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 5);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+    } else {
+        ASSERT_THAT(
+            recorded_events,
+            testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    }
 
     ASSERT_EQ(data(), 4);
 }
@@ -381,7 +438,7 @@ TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-            // MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "continuation")),
+            // MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
             MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 
@@ -398,8 +455,6 @@ TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
  *                                                                                 /
  * schedule(esc_C) | then('C') ---------------------------------------------------
  * @endverbatim
- *
- * @todo C cannot currently overlap with either of A, B or D.
  */
 TEST_F(WhenAllTest, nested_when_all_with_independent_branch) {
     const auto [exec_A, exec_B, exec_C] = Kokkos::Experimental::partition_space(exec, 1, 1, 1);
@@ -425,20 +480,32 @@ TEST_F(WhenAllTest, nested_when_all_with_independent_branch) {
                 MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "continuation"))));
+                MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "after dispatch"))));
+    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+        ASSERT_EQ(recorded_events.size(), 10);
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"));
+        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
+        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"));
+        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_RECORD_EVENT(exec_C));
+        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
+        ASSERT_THAT(recorded_events.at(6), MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"));
+        ASSERT_THAT(recorded_events.at(7), MATCHER_FOR_RECORD_EVENT(exec_A));
+        ASSERT_THAT(recorded_events.at(8), MATCHER_FOR_WAIT_EVENT(recorded_events.at(4)));
+        ASSERT_THAT(recorded_events.at(9), MATCHER_FOR_WAIT_EVENT(recorded_events.at(7)));
     } else {
         ASSERT_THAT(
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "continuation")),
+                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "continuation"))));
+                MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "after dispatch"))));
     }
 }
 


### PR DESCRIPTION
Instead of using a `fence` at the end of the branch, which blocks the main thread that cannot visit other branches, this PR uses events for the backends that support it (CUDA and HIP).

The event is waited by a sender that is given to the delegation scheduler, to ensure that at some point the GPU makes progress.

This PR needs:
* #95