### PR TITLE
ExecutionSpace: allow tag to be retrieved from customised parallel_for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ target_sources(
             kokkos-execution/impl/completion_signatures.hpp
             kokkos-execution/impl/continues_on.hpp
             kokkos-execution/impl/env.hpp
+            kokkos-execution/impl/sender_concepts.hpp
             kokkos-execution/impl/sync_wait.hpp
             kokkos-execution/utils/ignore_warnings.hpp
 )

--- a/kokkos-execution/execution_space/bulk.hpp
+++ b/kokkos-execution/execution_space/bulk.hpp
@@ -37,6 +37,7 @@ struct TransformSenderFor<stdexec::bulk_t> {
         Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
                  sndr_t<Sndr, Data, Env>,
+                 parallel_for_t,
                  typename sndr_t<Sndr, Data, Env>::closure_t&&,
                  Sndr&&
         >) {
@@ -45,6 +46,7 @@ struct TransformSenderFor<stdexec::bulk_t> {
         auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
         return sndr_t<Sndr, Data, Env>{
+            {},
             {{std::string(std::format("{}: bulk", Kokkos::Impl::TypeInfo<execution_space<Sndr, Env>>::name())),
               stdexec::__forward_like<Data>(functor),
               policy_t<Sndr, Env>(schd.state->exec, 0, shape)}},

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -5,6 +5,7 @@
 
 #include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/env.hpp"
+#include "kokkos-execution/impl/sender_concepts.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -34,6 +34,7 @@ struct ParallelForSender {
     using closure_t = ParallelForClosure<Functor, ExecPolicy>;
     using execution_space = typename closure_t::execution_space;
 
+    parallel_for_t tag;
     closure_t clsr;
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
@@ -67,6 +68,7 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
             "The policy's execution space type must be the same as the completion scheduler's execution space type.");
 
         return ParallelForSender<Sndr, functor_t, policy_t>{
+            {},
             {{std::move(label),
               std::move(functor),
               policy_t(Kokkos::Impl::PolicyUpdate{}, std::move(policy), schd.state->exec)}},
@@ -75,5 +77,17 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
 };
 
 } // namespace Kokkos::Execution::ExecutionSpaceImpl
+
+#if !STDEXEC_HAS_BUILTIN(__builtin_structured_binding_size)
+namespace stdexec {
+
+//! See also https://cor3ntin.github.io/posts/clang21/#__builtin_structured_binding_size.
+template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+inline constexpr auto __structured_binding_size_v< // NOLINT(bugprone-reserved-identifier)
+    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Functor, ExecPolicy>
+> = 3;
+
+} // namespace stdexec
+#endif
 
 #endif // KOKKOS_EXECUTION_EXECUTION_SPACE_PARALLEL_FOR_HPP

--- a/kokkos-execution/execution_space/then.hpp
+++ b/kokkos-execution/execution_space/then.hpp
@@ -38,12 +38,14 @@ struct TransformSenderFor<stdexec::then_t> {
     auto operator()(const Env& env, stdexec::then_t, Functor&& functor, Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
                  sndr_t<Sndr, Functor, Env>,
+                 parallel_for_t,
                  typename sndr_t<Sndr, Functor, Env>::closure_t&&,
                  Sndr&&
         >) {
         auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
         return sndr_t<Sndr, Functor, Env>{
+            {},
             {{std::string(std::format("{}: then", Kokkos::Impl::TypeInfo<execution_space<Sndr, Env>>::name())),
               ThenWrapper<Functor>{std::forward<Functor>(functor)},
               policy_t<Sndr, Env>(schd.state->exec, 0, 1)}},

--- a/kokkos-execution/impl/sender_concepts.hpp
+++ b/kokkos-execution/impl/sender_concepts.hpp
@@ -1,0 +1,23 @@
+#ifndef KOKKOS_EXECUTION_IMPL_SENDER_CONCEPTS_HPP
+#define KOKKOS_EXECUTION_IMPL_SENDER_CONCEPTS_HPP
+
+#include "kokkos-execution/parallel_for.hpp"
+#include "kokkos-execution/stdexec.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+//! Concept that constrains the type of a sender that dispatches a functor for execution.
+template <typename Sndr>
+concept dispatching_sender = stdexec::sender<Sndr> && requires {
+    typename stdexec::tag_of_t<Sndr>;
+    requires stdexec::__one_of<
+        stdexec::tag_of_t<Sndr>,
+        stdexec::bulk_t,
+        stdexec::then_t,
+        Kokkos::Execution::parallel_for_t
+    >;
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_SENDER_CONCEPTS_HPP

--- a/tests/execution_space/test_bulk.cpp
+++ b/tests/execution_space/test_bulk.cpp
@@ -54,6 +54,9 @@ consteval bool test_sndr_traits() {
                   >
     >);
 
+    //! Models the dispatching sender concept.
+    static_assert(Kokkos::Execution::Impl::dispatching_sender<bulk_sndr_t>);
+
     return true;
 }
 static_assert(test_sndr_traits());

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -35,8 +35,8 @@ class ParallelForTest
 };
 
 /**
- * @test Check traits of sender returned by @c Kokkos::Execution::parallel_for either uncustomized
- *       or customized for @c Kokkos::Execution::ExecutionSpaceContext.
+ * @test Check traits of sender returned by @ref Kokkos::Execution::parallel_for either uncustomized
+ *       or customized for @ref Kokkos::Execution::ExecutionSpaceContext.
  */
 template <template <typename, typename, typename> class SndrAdptr>
 consteval bool test_sndr_traits() {
@@ -50,6 +50,9 @@ consteval bool test_sndr_traits() {
 
     //! Models the sender concept.
     static_assert(stdexec::sender<pfor_sndr_t>);
+
+    //! Models the dispatching sender concept.
+    static_assert(Kokkos::Execution::Impl::dispatching_sender<pfor_sndr_t>);
 
     //! Has the expected completion signatures.
     using completion_signatures_t = stdexec::__completion_signatures_of_t<pfor_sndr_t, stdexec::env<>>;
@@ -80,9 +83,9 @@ consteval bool test_sndr_traits() {
     >);
 
     /**
-     * It is not no throw connectable because the @c ParallelForClosure is not no throw move constructible.
-     * This is so because it holds a functor that holds a @c Kokkos::View, and the latter are not no throw
-     * move constructible.
+     * It is not no throw connectable because the @ref Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure
+     * is not no throw move constructible. This is so because it holds a functor that holds a @c Kokkos::View,
+     * and the latter are not no throw move constructible.
      *
      * See also https://github.com/kokkos/kokkos/pull/8792.
      */
@@ -94,7 +97,7 @@ consteval bool test_sndr_traits() {
 
     return true;
 }
-static_assert(test_sndr_traits<Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender>());
+static_assert(test_sndr_traits<Kokkos::Execution::Impl::ParallelForSender>());
 static_assert(test_sndr_traits<Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender>());
 
 //! @test Check decomposition of @ref Kokkos::Execution::Impl::ParallelForSender into the algorithm tag, data, and child sender.
@@ -116,7 +119,7 @@ consteval bool test_sndr_decomposition() {
     static_assert(stdexec::__nbr_children_of<pfor_sndr_t> == 1);
     static_assert(std::same_as<stdexec::__child_of<pfor_sndr_t>, schd_sndr_t>);
 
-    //! Is transformable via @c Kokkos::Execution::ExecutionSpaceImpl::TransformSenderFor.
+    //! Is transformable via @ref Kokkos::Execution::ExecutionSpaceImpl::TransformSenderFor.
     static_assert(stdexec::__applicable<
                   Kokkos::Execution::ExecutionSpaceImpl::TransformSenderFor<stdexec::tag_of_t<pfor_sndr_t>>,
                   pfor_sndr_t,

--- a/tests/execution_space/test_then.cpp
+++ b/tests/execution_space/test_then.cpp
@@ -33,7 +33,7 @@ class ThenTest
     using variant_t = typename recorder_listener_t::event_variant_t;
 };
 
-//! @test Check traits of sender returned by @c then when customized for @c Kokkos::Execution::ExecutionSpaceImpl::Domain.
+//! @test Check traits of sender returned by @c then when customized for @ref Kokkos::Execution::ExecutionSpaceImpl::Domain.
 consteval bool test_sndr_traits() {
     //! Schedule sender.
     using schd_sndr_t = typename ThenTest::schedule_sender_t;
@@ -44,6 +44,9 @@ consteval bool test_sndr_traits() {
         decltype(stdexec::then(std::declval<schd_sndr_t>(), std::declval<functor_t>())),
         stdexec::env<>
     >;
+
+    //! Models the dispatching sender concept.
+    static_assert(Kokkos::Execution::Impl::dispatching_sender<then_sndr_t>);
 
     //! The policy used in the parallel for created by the @c then sender has the expected launch bounds.
     using policy_t = typename then_sndr_t::closure_t::policy_t;


### PR DESCRIPTION
This PR introduces:
- a `tag` member to `ParallelForSender` so that it can be queried for its tag through structured binding.
- a `dispatching_sender` concept to constraint senders that dispatch computation with `then`, `bulk` or `parallel_for`.