### PR TITLE
ExecutionSpace: allow dispatch label to be `string_view`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ target_sources(
             kokkos-execution/impl/bulk.hpp
             kokkos-execution/impl/completion_signatures.hpp
             kokkos-execution/impl/continues_on.hpp
+            kokkos-execution/impl/dispatch_label.hpp
             kokkos-execution/impl/env.hpp
             kokkos-execution/impl/sender_concepts.hpp
             kokkos-execution/impl/sync_wait.hpp

--- a/cmake/modules/warnings.cmake
+++ b/cmake/modules/warnings.cmake
@@ -18,7 +18,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     # For Clang, diagnostic flags are listed at https://clang.llvm.org/docs/DiagnosticsReference.html.
     add_compile_options(
       -Werror=unused-private-field -Werror=unused-lambda-capture -Werror=unused-member-function
-      -Werror=delete-non-virtual-dtor
+      -Werror=delete-non-virtual-dtor -Werror=dangling-gsl
     )
   endif()
 

--- a/kokkos-execution/execution_space/bulk.hpp
+++ b/kokkos-execution/execution_space/bulk.hpp
@@ -7,51 +7,46 @@
 #include "kokkos-execution/execution_space/sender_concepts.hpp"
 #include "kokkos-execution/execution_space/sender_introspection.hpp"
 #include "kokkos-execution/impl/bulk.hpp"
+#include "kokkos-execution/impl/dispatch_label.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
 template <>
 struct TransformSenderFor<stdexec::bulk_t> {
-    template <typename Sndr, typename Env>
-    using schd_t = stdexec::__completion_scheduler_of_t<stdexec::set_value_t, Sndr, const Env&>;
-
-    template <typename Sndr, typename Env>
-    using execution_space = typename schd_t<Sndr, Env>::execution_space;
-
-    template <typename Sndr, typename Env>
-    using policy_t = Kokkos::RangePolicy<execution_space<Sndr, Env>>;
-
-    template <typename Data>
-    using functor_t = typename Kokkos::Execution::Impl::bulk_traits<Data>::functor_t;
-
-    template <typename Sndr, typename Data, typename Env>
-    using sndr_t = ParallelForSender<Sndr, functor_t<Data>, policy_t<Sndr, Env>>;
+    template <typename Env, typename Data, typename Sndr>
+    using trnsfrmd_sndr_t = ParallelForSender<
+        Sndr,
+        std::string_view,
+        typename Kokkos::Execution::Impl::bulk_traits<Data>::functor_t,
+        Kokkos::RangePolicy<exec_of_t<Sndr, Env>>
+    >;
 
     template <
         typename Env,
         Kokkos::Execution::Impl::has_parallel_policy Data,
         execution_space_completing_sender<Env> Sndr
     >
+    requires requires { typename exec_of_t<Sndr, Env>; }
     auto operator()(
         const Env& env,
         stdexec::bulk_t,
         Data&& data, // NOLINT(cppcoreguidelines-missing-std-forward)
         Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
-                 sndr_t<Sndr, Data, Env>,
+                 trnsfrmd_sndr_t<Env, Data, Sndr>,
                  parallel_for_t,
-                 typename sndr_t<Sndr, Data, Env>::closure_t&&,
+                 typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t&&,
                  Sndr&&
         >) {
         auto& [parallel_policy, shape, functor] = data;
 
         auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
-        return sndr_t<Sndr, Data, Env>{
-            {},
-            {{std::string(std::format("{}: bulk", Kokkos::Impl::TypeInfo<execution_space<Sndr, Env>>::name())),
+        return trnsfrmd_sndr_t<Env, Data, Sndr>{
+            parallel_for_t{},
+            {{Impl::dispatch_label<exec_of_t<Sndr, Env>, ": bulk">(),
               stdexec::__forward_like<Data>(functor),
-              policy_t<Sndr, Env>(schd.state->exec, 0, shape)}},
+              Kokkos::RangePolicy<exec_of_t<Sndr, Env>>(schd.state->exec, 0, shape)}},
             std::forward<Sndr>(sndr)};
     }
 };

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -13,15 +13,19 @@
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
-template <typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 struct ParallelForClosure {
     using policy_t = ExecPolicy;
     using execution_space = typename policy_t::execution_space;
 
-    Kokkos::Execution::Impl::ParallelForData<Functor, policy_t> data;
+    Kokkos::Execution::Impl::ParallelForData<Label, Functor, policy_t> data;
 
     void execute() const & {
-        Kokkos::parallel_for(data.label, data.policy, data.functor);
+        if constexpr (std::convertible_to<Label, std::string>) {
+            Kokkos::parallel_for(data.label, data.policy, data.functor);
+        } else {
+            Kokkos::parallel_for(std::string{data.label}, data.policy, data.functor);
+        }
     }
 
     const policy_t& get_policy() const & noexcept {
@@ -29,11 +33,11 @@ struct ParallelForClosure {
     }
 };
 
-template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 struct ParallelForSender {
     using sender_concept = stdexec::sender_t;
 
-    using closure_t = ParallelForClosure<Functor, ExecPolicy>;
+    using closure_t = ParallelForClosure<Label, Functor, ExecPolicy>;
     using execution_space = typename closure_t::execution_space;
 
     parallel_for_t tag;
@@ -54,26 +58,40 @@ struct ParallelForSender {
 
 template <>
 struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
-    template <typename Env, typename Data, execution_space_completing_sender<Env> Sndr>
-    auto operator()(const Env& env, Kokkos::Execution::parallel_for_t, Data&& data, Sndr&& sndr) const noexcept {
-        auto [label, functor, policy] = std::forward<Data>(data);
+    template <typename Env, typename Data, typename Sndr>
+    using trnsfrmd_sndr_t = ParallelForSender<
+        Sndr,
+        typename std::remove_cvref_t<Data>::label_t,
+        typename std::remove_cvref_t<Data>::functor_t,
+        typename std::remove_cvref_t<Data>::policy_t
+    >;
 
-        using functor_t = decltype(functor);
-        using policy_t = decltype(policy);
-        using closure_t = ParallelForClosure<functor_t, policy_t>;
+    template <typename Env, typename Data, execution_space_completing_sender<Env> Sndr>
+    auto operator()(const Env& env, Kokkos::Execution::parallel_for_t, Data&& data, Sndr&& sndr) const
+        noexcept(std::is_nothrow_constructible_v<
+                 trnsfrmd_sndr_t<Env, Data, Sndr>,
+                 parallel_for_t,
+                 typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t&&,
+                 Sndr&&
+        >) {
+        auto [label, functor, policy] = std::forward<Data>(data);
 
         auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
         //! Only the execution space instance, not its type, can be bound lately.
         static_assert(
-            std::same_as<typename decltype(schd)::execution_space, typename closure_t::execution_space>,
+            std::same_as<
+                typename decltype(schd)::execution_space,
+                typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t::execution_space
+            >,
             "The policy's execution space type must be the same as the completion scheduler's execution space type.");
 
-        return ParallelForSender<Sndr, functor_t, policy_t>{
-            {},
+        return trnsfrmd_sndr_t<Env, Data, Sndr>{
+            parallel_for_t{},
             {{std::move(label),
               std::move(functor),
-              policy_t(Kokkos::Impl::PolicyUpdate{}, std::move(policy), schd.state->exec)}},
+              typename std::remove_cvref_t<Data>::policy_t(
+                  Kokkos::Impl::PolicyUpdate{}, std::move(policy), schd.state->exec)}},
             std::forward<Sndr>(sndr)};
     }
 };
@@ -84,9 +102,9 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
 namespace stdexec {
 
 //! See also https://cor3ntin.github.io/posts/clang21/#__builtin_structured_binding_size.
-template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 inline constexpr auto __structured_binding_size_v< // NOLINT(bugprone-reserved-identifier)
-    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Functor, ExecPolicy>
+    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Label, Functor, ExecPolicy>
 > = 3;
 
 } // namespace stdexec

--- a/kokkos-execution/execution_space/then.hpp
+++ b/kokkos-execution/execution_space/then.hpp
@@ -6,6 +6,7 @@
 #include "kokkos-execution/execution_space/parallel_for.hpp"
 #include "kokkos-execution/execution_space/sender_concepts.hpp"
 #include "kokkos-execution/execution_space/sender_introspection.hpp"
+#include "kokkos-execution/impl/dispatch_label.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
@@ -24,31 +25,25 @@ struct ThenWrapper {
 template <>
 struct TransformSenderFor<stdexec::then_t> {
     template <typename Sndr, typename Env>
-    using schd_t = stdexec::__completion_scheduler_of_t<stdexec::set_value_t, Sndr, const Env&>;
+    using policy_t = Kokkos::RangePolicy<exec_of_t<Sndr, Env>, Kokkos::LaunchBounds<1>>;
 
-    template <typename Sndr, typename Env>
-    using execution_space = typename schd_t<Sndr, Env>::execution_space;
-
-    template <typename Sndr, typename Env>
-    using policy_t = Kokkos::RangePolicy<execution_space<Sndr, Env>, Kokkos::LaunchBounds<1>>;
-
-    template <typename Sndr, typename Functor, typename Env>
-    using sndr_t = ParallelForSender<Sndr, ThenWrapper<Functor>, policy_t<Sndr, Env>>;
+    template <typename Env, typename Functor, typename Sndr>
+    using trnsfrmd_sndr_t = ParallelForSender<Sndr, std::string_view, ThenWrapper<Functor>, policy_t<Sndr, Env>>;
 
     template <typename Env, typename Functor, execution_space_completing_sender<Env> Sndr>
-    requires requires { typename schd_t<Sndr, Env>; }
+    requires requires { typename exec_of_t<Sndr, Env>; }
     auto operator()(const Env& env, stdexec::then_t, Functor&& functor, Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
-                 sndr_t<Sndr, Functor, Env>,
+                 trnsfrmd_sndr_t<Env, Functor, Sndr>,
                  parallel_for_t,
-                 typename sndr_t<Sndr, Functor, Env>::closure_t&&,
+                 typename trnsfrmd_sndr_t<Env, Functor, Sndr>::closure_t&&,
                  Sndr&&
         >) {
         auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
-        return sndr_t<Sndr, Functor, Env>{
-            {},
-            {{std::string(std::format("{}: then", Kokkos::Impl::TypeInfo<execution_space<Sndr, Env>>::name())),
+        return trnsfrmd_sndr_t<Env, Functor, Sndr>{
+            parallel_for_t{},
+            {{Impl::dispatch_label<exec_of_t<Sndr, Env>, ": then">(),
               ThenWrapper<Functor>{std::forward<Functor>(functor)},
               policy_t<Sndr, Env>(schd.state->exec, 0, 1)}},
             std::forward<Sndr>(sndr)};

--- a/kokkos-execution/impl/dispatch_label.hpp
+++ b/kokkos-execution/impl/dispatch_label.hpp
@@ -1,0 +1,53 @@
+#ifndef KOKKOS_EXECUTION_IMPL_DISPATCH_LABEL_HPP
+#define KOKKOS_EXECUTION_IMPL_DISPATCH_LABEL_HPP
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+#include "Kokkos_Core.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+template <size_t N>
+struct FixedString {
+    char data[N]{};
+
+    consteval FixedString(const char (&str)[N]) noexcept { // NOLINT(google-explicit-constructor)
+        std::copy_n(str, N, data);
+    }
+
+    consteval auto size() const {
+        return N - 1;
+    }
+
+    consteval auto begin() const {
+        return data;
+    }
+    consteval auto end() const {
+        return data + N - 1;
+    }
+};
+
+//! Get the dispatch label from @p Exec and @p Suffix.
+template <Kokkos::ExecutionSpace Exec, FixedString Suffix>
+static constexpr auto dispatch_label_v = [] {
+    constexpr auto prefix = Kokkos::Impl::TypeInfo<Exec>::name();
+    std::array<char, prefix.size() + Suffix.size() + 1> buf{};
+    auto iter = buf.begin();
+    for (auto charac: prefix)
+        *iter++ = charac;
+    for (auto charac: Suffix)
+        *iter++ = charac;
+    return buf;
+}();
+
+//! View the dispatch label as a @c std::string_view.
+template <Kokkos::ExecutionSpace Exec, FixedString Suffix>
+consteval std::string_view dispatch_label() noexcept {
+    return {dispatch_label_v<Exec, Suffix>.data(), dispatch_label_v<Exec, Suffix>.size() - 1};
+}
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_DISPATCH_LABEL_HPP

--- a/kokkos-execution/parallel_for.hpp
+++ b/kokkos-execution/parallel_for.hpp
@@ -9,7 +9,7 @@ namespace Kokkos::Execution {
 
 namespace Impl {
 
-template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 struct ParallelForSender;
 
 } // namespace Impl
@@ -43,30 +43,32 @@ struct parallel_for_t {
 
     template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
     constexpr auto operator()(Sndr&& sndr, std::string label, ExecPolicy policy, Functor functor) const {
-        return Impl::ParallelForSender<Sndr, Functor, ExecPolicy>(
+        return Impl::ParallelForSender<Sndr, std::string, Functor, ExecPolicy>(
             {std::move(label), std::move(functor), std::move(policy)}, std::forward<Sndr>(sndr));
     }
 };
 
 namespace Impl {
-template <typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+
+template <typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 struct ParallelForData {
+    using label_t = Label;
     using functor_t = Functor;
     using policy_t = ExecPolicy;
 
-    std::string label;
+    label_t label;
     functor_t functor;
     policy_t policy;
 };
 
-template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
-struct ParallelForSender : stdexec::__tuple<parallel_for_t, ParallelForData<Functor, ExecPolicy>, Sndr> {
+template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+struct ParallelForSender : stdexec::__tuple<parallel_for_t, ParallelForData<Label, Functor, ExecPolicy>, Sndr> {
     using sender_concept = stdexec::sender_t;
 
-    using base_t = stdexec::__tuple<parallel_for_t, ParallelForData<Functor, ExecPolicy>, Sndr>;
+    using base_t = stdexec::__tuple<parallel_for_t, ParallelForData<Label, Functor, ExecPolicy>, Sndr>;
 
     ParallelForSender(
-        ParallelForData<Functor, ExecPolicy> data,
+        ParallelForData<Label, Functor, ExecPolicy> data,
         Sndr&& sndr) // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         : base_t{parallel_for_t{}, std::move(data), std::forward<Sndr>(sndr)} {
     }

--- a/tests/execution_space/test_bulk.cpp
+++ b/tests/execution_space/test_bulk.cpp
@@ -49,6 +49,7 @@ consteval bool test_sndr_traits() {
                   bulk_sndr_t,
                   Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<
                       schd_sndr_t,
+                      std::string_view,
                       functor_t,
                       Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
                   >
@@ -113,6 +114,7 @@ constexpr bool test_op_state_passed_by_const_ref() {
                       const typename BulkTest::schedule_sender_t&,
                       Tests::Utils::SinkReceiver,
                       Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+                          std::string_view,
                           Tests::Utils::Functors::Labeled<'a'>,
                           Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
                       >

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -124,6 +124,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             Kokkos::Execution::ExecutionSpaceImpl::SyncWaitReceiver<host_execution_space>,
             Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+                std::string_view,
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'h'>>,
                 Kokkos::RangePolicy<host_execution_space, Kokkos::LaunchBounds<1>>
             >
@@ -164,6 +165,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             sfrom_con_h_then_rcvr_t,
             Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+                std::string_view,
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'B'>>,
                 Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
             >
@@ -214,6 +216,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             sfrom_con_B_then_sfrom_con_h_then_rcvr_t,
             Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+                std::string_view,
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'A'>>,
                 Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
             >

--- a/tests/execution_space/test_operation_state.cpp
+++ b/tests/execution_space/test_operation_state.cpp
@@ -27,7 +27,7 @@ consteval bool test_op_state_traits() {
     //! Parallel for closure.
     using functor_t = Tests::Utils::Functors::SumIndices<typename OpStateTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using clsr_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<functor_t, policy_t>;
+    using clsr_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<std::string, functor_t, policy_t>;
 
     //! Receiver.
     using rcvr_t = Tests::Utils::SinkReceiver;
@@ -71,6 +71,7 @@ constexpr bool test_op_state_passed_by_const_ref() {
                       const typename OpStateTest::schedule_sender_t&,
                       Tests::Utils::SinkReceiver,
                       Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+                          std::string,
                           Tests::Utils::Functors::Labeled<'a'>,
                           Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
                       >

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -38,15 +38,16 @@ class ParallelForTest
  * @test Check traits of sender returned by @ref Kokkos::Execution::parallel_for either uncustomized
  *       or customized for @ref Kokkos::Execution::ExecutionSpaceContext.
  */
-template <template <typename, typename, typename> class SndrAdptr>
+template <template <typename, typename, typename, typename> class SndrAdptr>
 consteval bool test_sndr_traits() {
     //! Schedule sender.
     using schd_sndr_t = typename ParallelForTest::schedule_sender_t;
 
     //! Parallel for sender.
+    using label_t = std::string;
     using functor_t = Tests::Utils::Functors::SumIndices<typename ParallelForTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using pfor_sndr_t = SndrAdptr<schd_sndr_t, functor_t, policy_t>;
+    using pfor_sndr_t = SndrAdptr<schd_sndr_t, label_t, functor_t, policy_t>;
 
     //! Models the execution space completing sender concept.
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::execution_space_completing_sender<pfor_sndr_t>);
@@ -80,7 +81,7 @@ consteval bool test_sndr_traits() {
 
     static_assert(std::same_as<
                   stdexec::transform_sender_result_t<pfor_sndr_t, stdexec::env_of_t<Tests::Utils::SinkReceiver>>,
-                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, functor_t, policy_t>
+                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>
     >);
 
     /**
@@ -92,7 +93,7 @@ consteval bool test_sndr_traits() {
      */
     static_assert(!std::is_nothrow_move_constructible_v<typename ParallelForTest::view_s_t>);
     static_assert(!std::is_nothrow_move_constructible_v<functor_t>);
-    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<functor_t, policy_t>;
+    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<label_t, functor_t, policy_t>;
     static_assert(!std::is_nothrow_move_constructible_v<closure_t>);
     static_assert(!stdexec::__nothrow_connectable<pfor_sndr_t, Tests::Utils::SinkReceiver>);
 
@@ -107,15 +108,18 @@ consteval bool test_sndr_decomposition() {
     using schd_sndr_t = typename ParallelForTest::schedule_sender_t;
 
     //! Parallel for sender.
+    using label_t = std::string;
     using functor_t = Tests::Utils::Functors::SumIndices<typename ParallelForTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using pfor_sndr_t = Kokkos::Execution::Impl::ParallelForSender<schd_sndr_t, functor_t, policy_t>;
+    using pfor_sndr_t = Kokkos::Execution::Impl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>;
 
     //! Is decomposable into the expected algorithm tag, data, and child sender.
     static_assert(std::same_as<stdexec::tag_of_t<pfor_sndr_t>, Kokkos::Execution::parallel_for_t>);
 
-    static_assert(
-        std::same_as<stdexec::__data_of<pfor_sndr_t>, Kokkos::Execution::Impl::ParallelForData<functor_t, policy_t>>);
+    static_assert(std::same_as<
+                  stdexec::__data_of<pfor_sndr_t>,
+                  Kokkos::Execution::Impl::ParallelForData<label_t, functor_t, policy_t>
+    >);
 
     static_assert(stdexec::__nbr_children_of<pfor_sndr_t> == 1);
     static_assert(std::same_as<stdexec::__child_of<pfor_sndr_t>, schd_sndr_t>);
@@ -136,7 +140,7 @@ template <typename ViewType, bool ExpectNoThrowMoveConstructible>
 consteval bool test_closure_traits() {
     using functor_t = Tests::Utils::Functors::SumIndices<ViewType>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<functor_t, policy_t>;
+    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<std::string, functor_t, policy_t>;
 
     //! Models the @ref Kokkos::Execution::ExecutionSpaceImpl::Closure concept.
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::Closure<closure_t>);


### PR DESCRIPTION
So that our noexcept expressions don't need to account for the string allocation anymore.