### PR TITLE
kokkos(view): is `nothrow` except for `Cuda`

### DIFF
--- a/tests/execution_space/test_let_value.cpp
+++ b/tests/execution_space/test_let_value.cpp
@@ -56,12 +56,22 @@ TEST_F(LetValueTest, scoped_allocation) {
     static_assert(
         Tests::Utils::has_completion_signatures<decltype(allocate), stdexec::__mset<stdexec::set_value_t(view_of_5_t)>>);
 
+//! FIXME: https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/Kokkos_View.hpp#L697
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
     //! @c Kokkos::View is not nothrow movable, so the error channel is added.
     static_assert(Tests::Utils::has_completion_signatures<
                   decltype(allocate),
                   stdexec::__mset<stdexec::set_value_t(view_of_5_t), stdexec::set_error_t(std::exception_ptr)>,
                   stdexec::env<>
     >);
+#else
+    //! @c Kokkos::View is nothrow movable, so the error channel is not added.
+    static_assert(Tests::Utils::has_completion_signatures<
+                  decltype(allocate),
+                  stdexec::__mset<stdexec::set_value_t(view_of_5_t)>,
+                  stdexec::env<>
+    >);
+#endif
 
     //! Use the scratch view to make some meaningful computation.
     auto run = std::move(allocate) // NOLINT(performance-move-const-arg)

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -84,6 +84,8 @@ consteval bool test_sndr_traits() {
                   Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>
     >);
 
+//! FIXME: https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/Kokkos_View.hpp#L697
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
     /**
      * It is not no throw connectable because the @ref Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure
      * is not no throw move constructible. This is so because it holds a functor that holds a @c Kokkos::View,
@@ -96,6 +98,10 @@ consteval bool test_sndr_traits() {
     using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<label_t, functor_t, policy_t>;
     static_assert(!std::is_nothrow_move_constructible_v<closure_t>);
     static_assert(!stdexec::__nothrow_connectable<pfor_sndr_t, Tests::Utils::SinkReceiver>);
+#else
+    //! It is nothrow connectable.
+    static_assert(stdexec::__nothrow_connectable<pfor_sndr_t, Tests::Utils::SinkReceiver>);
+#endif
 
     return true;
 }
@@ -149,7 +155,12 @@ consteval bool test_closure_traits() {
 
     return true;
 }
+//! FIXME: https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/Kokkos_View.hpp#L697
+#if defined(KOKKOS_COMPILER_CLANG) && defined(KOKKOS_ENABLE_CUDA)
 static_assert(test_closure_traits<typename ParallelForTest::view_s_t, false>());
+#else
+static_assert(test_closure_traits<typename ParallelForTest::view_s_t, true>());
+#endif
 static_assert(test_closure_traits<std::span<int>, true>());
 
 //! @test Check @ref Kokkos::Execution::parallel_for with a team policy.


### PR DESCRIPTION
Extracted from:
- #95

Credits to @maartenarnst.