### PR TITLE
events(hpx): use hpx::lcos::local::event instead of sender

### DIFF
--- a/kokkos-execution/impl/Cuda/event.hpp
+++ b/kokkos-execution/impl/Cuda/event.hpp
@@ -19,7 +19,6 @@ struct Event<Kokkos::Cuda> {
     using mark_event_t = MarkEvent<Kokkos::Cuda>;
 
     cudaEvent_t event = nullptr;
-    mutable bool arrived = false;
 
     Event() = default;
 
@@ -30,8 +29,7 @@ struct Event<Kokkos::Cuda> {
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&& other) noexcept
-        : event(std::exchange(other.event, nullptr))
-        , arrived(std::exchange(other.arrived, false)) {
+        : event(std::exchange(other.event, nullptr)) {
     }
     Event& operator=(Event&& other) noexcept {
         if (this != &other) {
@@ -39,7 +37,6 @@ struct Event<Kokkos::Cuda> {
                 KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventDestroy(event));
             }
             event = std::exchange(other.event, nullptr);
-            arrived = std::exchange(other.arrived, false);
         }
         return *this;
     }
@@ -54,15 +51,13 @@ struct Event<Kokkos::Cuda> {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
         }
         KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(event, exec.cuda_stream()));
-        arrived = false;
         mark_event_t::record(static_cast<void*>(event), exec);
     }
 
     void wait() const {
-        if (!arrived) {
-            mark_event_t::wait(static_cast<void*>(event));
+        mark_event_t::wait(static_cast<void*>(event));
+        if (cudaEventQuery(event) != cudaSuccess) {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(event));
-            arrived = true;
         }
     }
 };

--- a/kokkos-execution/impl/HIP/event.hpp
+++ b/kokkos-execution/impl/HIP/event.hpp
@@ -19,7 +19,6 @@ struct Event<Kokkos::HIP> {
     using mark_event_t = MarkEvent<Kokkos::HIP>;
 
     hipEvent_t event = nullptr;
-    mutable bool arrived = false;
 
     Event() = default;
 
@@ -30,8 +29,7 @@ struct Event<Kokkos::HIP> {
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&& other) noexcept
-        : event(std::exchange(other.event, nullptr))
-        , arrived(std::exchange(other.arrived, false)) {
+        : event(std::exchange(other.event, nullptr)) {
     }
     Event& operator=(Event&& other) noexcept {
         if (this != &other) {
@@ -39,7 +37,6 @@ struct Event<Kokkos::HIP> {
                 KOKKOS_IMPL_HIP_SAFE_CALL(hipEventDestroy(event));
             }
             event = std::exchange(other.event, nullptr);
-            arrived = std::exchange(other.arrived, false);
         }
         return *this;
     }
@@ -54,15 +51,13 @@ struct Event<Kokkos::HIP> {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventCreateWithFlags(&event, hipEventDisableTiming));
         }
         KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(event, exec.hip_stream()));
-        arrived = false;
         mark_event_t::record(static_cast<void*>(event), exec);
     }
 
     void wait() const {
-        if (!arrived) {
-            mark_event_t::wait(static_cast<void*>(event));
+        mark_event_t::wait(static_cast<void*>(event));
+        if (hipEventQuery(event) != hipSuccess) {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(event));
-            arrived = true;
         }
     }
 };

--- a/kokkos-execution/impl/HPX/event.hpp
+++ b/kokkos-execution/impl/HPX/event.hpp
@@ -9,6 +9,10 @@
  * Specialization of @ref Kokkos::Execution::Impl::Event for @c Kokkos::Experimental::HPX.
  */
 
+#if !defined(KOKKOS_ENABLE_IMPL_HPX_ASYNC_DISPATCH)
+#    error "This is not supported."
+#endif
+
 namespace Kokkos::Execution::Impl {
 
 template <>
@@ -18,7 +22,7 @@ template <>
 struct Event<Kokkos::Experimental::HPX> {
     using mark_event_t = MarkEvent<Kokkos::Experimental::HPX>;
 
-    mutable std::optional<hpx::execution::experimental::any_sender<>> m_sender = std::nullopt;
+    std::shared_ptr<hpx::lcos::local::event> m_event = nullptr;
     void* m_id = nullptr; //! Used to keep a stable event ID across moves.
 
     Event() = default;
@@ -30,12 +34,12 @@ struct Event<Kokkos::Experimental::HPX> {
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&& other) noexcept
-        : m_sender(std::move(other.m_sender))
+        : m_event(std::move(other.m_event))
         , m_id(std::exchange(other.m_id, nullptr)) {
     }
     Event& operator=(Event&& other) noexcept {
         if (this != &other) {
-            m_sender = std::move(other.m_sender);
+            m_event = std::move(other.m_event);
             m_id = std::exchange(other.m_id, nullptr);
         }
         return *this;
@@ -43,16 +47,31 @@ struct Event<Kokkos::Experimental::HPX> {
     ~Event() = default;
 
     void record(const Kokkos::Experimental::HPX& exec) {
-        m_sender = exec.get_sender();
-        m_id = (void*) std::addressof(*m_sender);
+        /**
+         * Always allocate a new event. Otherwise, the sequence:
+         * @code
+         * event.record(exec_A);
+         * event.record(exec_B);
+         * event.wait();
+         * @endcode
+         * will be surprising to the user. Indeed, if the two successive calls to @ref record
+         * would use the same @ref m_event, the call to @ref wait would potentially complete
+         * due to @c exec_A, while the expectation is that it completes due to @c exec_B.
+         */
+        m_event = std::make_shared<hpx::lcos::local::event>();
+        exec.impl_bulk_plain_erased<int>(
+            false, /* force_synchronous */
+            true,  /* is_light_weight_policy */
+            [event = m_event](const auto) { event->set(); },
+            1);
+        m_id = (void*) std::addressof(*m_event);
         mark_event_t::record(m_id, exec);
     }
 
-    //! @note Consumes @ref m_sender.
     void wait() const {
-        if (m_sender.has_value()) {
-            mark_event_t::wait(m_id);
-            hpx::this_thread::experimental::sync_wait(*std::exchange(m_sender, std::nullopt));
+        mark_event_t::wait(m_id);
+        if (!m_event->occurred()) {
+            m_event->wait();
         }
     }
 };

--- a/tests/impl/test_event.cpp
+++ b/tests/impl/test_event.cpp
@@ -101,7 +101,7 @@ void test_event_record_and_wait(const Exec& exec) {
 
 KOKKOS_EXECUTION_TESTS_IMPL_EVENT(EventTest, record_and_wait, (exec))
 
-//! @test Record an event and wait for it many times. Check that it marks both steps once, and subsequent waits are just "for free".
+//! @test Record an event and wait for it many times. It marks all wait events.
 template <Kokkos::ExecutionSpace Exec>
 void test_event_record_and_wait_many_times(const Exec& exec) {
     const auto recorded_events = EventTest::recorder_listener_t::record([&exec]() {
@@ -114,10 +114,14 @@ void test_event_record_and_wait_many_times(const Exec& exec) {
         event.wait();
     });
 
-    ASSERT_EQ(recorded_events.size(), 2);
+    ASSERT_THAT(recorded_events, ::testing::SizeIs(6));
     ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_EVENT_RECORD(exec));
     const auto event_id = extract_event_record_id(recorded_events.at(0));
     ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_EVENT_WAIT(TEST_EXECUTION_SPACE, event_id));
+    ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_EVENT_WAIT(TEST_EXECUTION_SPACE, event_id));
+    ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_EVENT_WAIT(TEST_EXECUTION_SPACE, event_id));
+    ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_EVENT_WAIT(TEST_EXECUTION_SPACE, event_id));
+    ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_EVENT_WAIT(TEST_EXECUTION_SPACE, event_id));
 }
 
 KOKKOS_EXECUTION_TESTS_IMPL_EVENT(EventTest, record_and_wait_many_times, (exec))
@@ -133,7 +137,7 @@ void test_event_record_and_wait_and_record_and_wait(const Exec& exec) {
         event.wait();
     });
 
-    ASSERT_EQ(recorded_events.size(), 4);
+    ASSERT_THAT(recorded_events, ::testing::SizeIs(4));
 
     ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_EVENT_RECORD(exec));
     auto event_id = extract_event_record_id(recorded_events.at(0));


### PR DESCRIPTION
Also, use CUDA/HIP event query to avoid the synchronization if not needed.

Also, move the "event wait" mark out of the if branch so that it is always marked.

This is a note I did that roughly explains it, and it's valid for any HPX instance:
```c++
    /**
     * @warning Using @c Kokkos::Experimental::HPX::get_sender with the default @c Kokkos::Experimental::HPX
     *          instance may lead to subtle and hard-to-diagnose errors during program termination.
     *
     * The default execution space instance relies on a static @c instance_data object whose lifetime extends until program shutdown,
     * see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L166
     *
     * Its destructor performs a final fence on the internally stored sender, see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L127
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L159
     *
     * This is generally safe as long as the sender chain does not retain references to any @c Kokkos::Experimental::HPX instance,
     * *e.g.* through the execution policy of a @c Kokkos::Impl::ParallelFor, see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L949
     *
     * However, calling @c Kokkos::Experimental::HPX::get_sender introduces a @c split sender, creating a shared state between
     * the returned sender and the internal sender stored in the instance data, see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L273
     *
     * While the caller may synchronize and destroy its copy of the shared state by calling
     * @c hpx::this_thread::experimental::sync_wait and disposing of it, the shared state remains owned by the instance data.
     *
     * This remaining state is only released when the instance data performs a @c fence_locked or during destruction of the
     * static @c instance_data object, see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L144
     *
     * If it occurs during destruction, it therefore occurs after @c Kokkos::finalize. And if the retained sender state indirectly owns an
     * @c Kokkos::Experimental::HPX instance, if violates the @c Kokkos precondition that all execution space instances must be destroyed prior
     * to @c Kokkos::finalize, resulting in a runtime error, see:
     *  * https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/HPX/Kokkos_HPX.hpp#L192
     *
     * To avoid this issue, event recording is disabled for the default instance and a fence is performed instead.
     */
```