### PR TITLE
ExecutionSpace: fix issue of additional kernel in `let_value`

### DIFF
--- a/tests/execution_space/test_let_value.cpp
+++ b/tests/execution_space/test_let_value.cpp
@@ -50,7 +50,8 @@ TEST_F(LetValueTest, scoped_allocation) {
     //! Allocate a @c Kokkos view only when the sender is running, put it in the value channel.
     auto allocate = stdexec::schedule(esc.get_scheduler())
                   | stdexec::let_value([this]() noexcept -> stdexec::sender auto {
-                        return stdexec::just(view_of_5_t{Kokkos::view_alloc(exec, "scratch")});
+                        return stdexec::just(
+                            view_of_5_t{Kokkos::view_alloc(exec, "scratch", Kokkos::WithoutInitializing)});
                     });
 
     static_assert(
@@ -75,22 +76,39 @@ TEST_F(LetValueTest, scoped_allocation) {
 
     //! Use the scratch view to make some meaningful computation.
     auto run = std::move(allocate) // NOLINT(performance-move-const-arg)
-             | stdexec::let_value(
-                   [&esc, &data, &stc](
-                       Kokkos::utils::concepts::ViewOfRank<1> auto const & scratch) noexcept -> stdexec::sender auto {
-                       return stdexec::schedule(esc.get_scheduler())
-                            | stdexec::bulk(
-                                  stdexec::par,
-                                  5,
-                                  KOKKOS_LAMBDA<std::integral T>(const T index) {
-                                      scratch(index) = index;
-                                      Kokkos::atomic_add(data.data(), scratch(index));
-                                  })
-                            | stdexec::continues_on(stc.get_scheduler())
-                            | stdexec::then([scratch]() mutable -> Kokkos::utils::concepts::ViewOfRank<1> auto {
-                                  return std::move(scratch);
-                              });
-                   });
+             /**
+              * The operation state of @c stdexec::let_value stores the arguments in a decayed tuple
+              * and passes references to them when invoking the lambda.
+              *
+              * - https://github.com/NVIDIA/stdexec/blob/f662722de0de4b4795c56fe8546ecf9412ec5a3f/include/stdexec/__detail/__let.hpp#L315
+              * - https://github.com/NVIDIA/stdexec/blob/f662722de0de4b4795c56fe8546ecf9412ec5a3f/include/stdexec/__detail/__let.hpp#L355
+              * - https://github.com/NVIDIA/stdexec/blob/f662722de0de4b4795c56fe8546ecf9412ec5a3f/include/stdexec/__detail/__let.hpp#L358
+              */
+             | stdexec::let_value([&esc, &data, &stc](auto&& scratch) noexcept -> stdexec::sender auto {
+                   static_assert(std::same_as<decltype(scratch), view_of_5_t&>);
+                   EXPECT_EQ(scratch.use_count(), 1);
+                   return stdexec::schedule(esc.get_scheduler())
+                        | stdexec::bulk(
+                              stdexec::par,
+                              5,
+                              KOKKOS_LAMBDA<std::integral T>(const T index) {
+                                  /**
+                                   * The use count includes the views in the @c stdexec::let_value operation state and the @c stdexec::bulk closure.
+                                   *
+                                   * There is also a copy in the @c Kokkos parallel region, but it is not included in the use count
+                                   * because of @c Kokkos::parallel_for uses @c Kokkos::Impl::construct_with_shared_allocation_tracking_disabled.
+                                   */
+                                  KOKKOS_IF_ON_HOST(EXPECT_EQ(scratch.use_count(), 2);)
+                                  scratch(index) = index;
+                                  Kokkos::atomic_add(data.data(), scratch(index));
+                              })
+                        | stdexec::continues_on(stc.get_scheduler())
+                        | stdexec::then([&scratch]() mutable -> Kokkos::utils::concepts::ViewOfRank<1> auto {
+                              //! The use count includes the views in the @c stdexec::let_value operation state and the @c stdexec::bulk closure.
+                              EXPECT_EQ(scratch.use_count(), 2);
+                              return std::move(scratch);
+                          });
+               });
 
     static_assert(Tests::Utils::has_completion_signatures<
                   decltype(run),
@@ -100,15 +118,36 @@ TEST_F(LetValueTest, scoped_allocation) {
 
     //! Check the result of the computation.
     auto check = std::move(run) // NOLINT(performance-move-const-arg)
-               | stdexec::let_value(
-                     [&esc, &data](
-                         Kokkos::utils::concepts::ViewOfRank<1> auto const & scratch) noexcept -> stdexec::sender auto {
-                         return stdexec::schedule(esc.get_scheduler())
-                              | stdexec::bulk(
-                                    stdexec::par, 5, KOKKOS_LAMBDA<std::integral T>(const T index) {
-                                        Kokkos::atomic_add(data.data(), scratch(index));
-                                    });
-                     });
+               | stdexec::let_value([&esc, &data](auto&& scratch) noexcept -> stdexec::sender auto {
+                     static_assert(std::same_as<decltype(scratch), view_of_5_t&>);
+                     /**
+                      * The implementation of @c stdexec::let_value uses a single variant to store the predecessor and successor operation states.
+                      *
+                      * The predecessor operation state is still alive when the lambda is invoked to construct the successor sender. The predecessor
+                      * operation state is destroyed only when the successor sender is connected and assigned to the variant.
+                      *
+                      * - https://github.com/NVIDIA/stdexec/blob/f662722de0de4b4795c56fe8546ecf9412ec5a3f/include/stdexec/__detail/__let.hpp#L357-L365
+                      * - https://github.com/NVIDIA/stdexec/blob/f662722de0de4b4795c56fe8546ecf9412ec5a3f/include/stdexec/__detail/__let.hpp#L382-L384
+                      *
+                      * The use count includes the views in the "run" @c stdexec::bulk closure and the "check" @c stdexec::let_value operation state.
+                      *
+                      * The "run" @c stdexec::then lambda moved the view held by the "run" @c stdexec::let_value operation state, so it no longer
+                      * contributes to the use count at this point.
+                      */
+                     EXPECT_EQ(scratch.use_count(), 2);
+                     return stdexec::schedule(esc.get_scheduler())
+                          | stdexec::bulk(
+                                stdexec::par, 5, KOKKOS_LAMBDA<std::integral T>(const T index) {
+                                    Kokkos::atomic_add(data.data(), scratch(index));
+                                    /**
+                                     * The use count includes the views in the "check" @c stdexec::let_value operation state and the @c stdexec::bulk closure
+                                     *
+                                     * There is also a copy in the @c Kokkos parallel region, but it is not included in the use count
+                                     * because of @c Kokkos::parallel_for uses @c Kokkos::Impl::construct_with_shared_allocation_tracking_disabled.
+                                     */
+                                    KOKKOS_IF_ON_HOST(EXPECT_EQ(scratch.use_count(), 2);)
+                                });
+                 });
 
     static_assert(Tests::Utils::has_completion_signatures<
                   decltype(check),


### PR DESCRIPTION
For the record, a typical error:
```bash
[8](https://github.com/uliegecsm/kokkos-execution/actions/runs/23639777859/job/68857414030#step:7:119)
[ RUN      ] LetValueTest.scoped_allocation
2026-03-27 09:30:57.877 DEBUG [2923] [Kokkos::Execution::ExecutionSpaceImpl::Domain::apply_sender@19] Kokkos::Execution::ExecutionSpaceImpl::Domain: apply_sender for tag stdexec::sync_wait_t
2026-03-27 09:30:57.877 DEBUG [2923] [Kokkos::Execution::ExecutionSpaceImpl::Domain::transform_sender@30] Kokkos::Execution::ExecutionSpaceImpl::Domain: transform_sender for tag stdexec::schedule_from_t
2026-03-27 09:30:57.877 DEBUG [2923] [Kokkos::Execution::ExecutionSpaceImpl::Domain::transform_sender@30] Kokkos::Execution::ExecutionSpaceImpl::Domain: transform_sender for tag stdexec::bulk_t
2026-03-27 09:30:57.877 DEBUG [2955] [Kokkos::Execution::ExecutionSpaceImpl::Domain::transform_sender@30] Kokkos::Execution::ExecutionSpaceImpl::Domain: transform_sender for tag stdexec::bulk_t
/__w/kokkos-execution/kokkos-execution/tests/execution_space/test_let_value.cpp:121: Failure
Value of: recorder_listener_t::record([check = std::move(check)]() mutable { stdexec::sync_wait(std::move(check)); })
Expected: contains in order elements that match (is a variant<> with value of type 'Kokkos::utils::callbacks::AllocateDataEvent' and the value (is an object whose given field is an object whose given field is equal to "scratch"), is a variant<> with value of type 'Kokkos::utils::callbacks::BeginParallelForEvent' and the value (is an object whose given field is equal to "Kokkos::Serial: bulk") and (is an object whose given field is equal to 1), is a variant<> with value of type 'Kokkos::utils::callbacks::BeginFenceEvent' and the value (is an object whose given field is equal to "Kokkos::Serial: schedule_from") and (is an object whose given field is equal to 1), is a variant<> with value of type 'Kokkos::utils::callbacks::BeginParallelForEvent' and the value (is an object whose given field is equal to "Kokkos::Serial: bulk") and (is an object whose given field is equal to 1), is a variant<> with value of type 'Kokkos::utils::callbacks::BeginFenceEvent' and the value (is an object whose given field is equal to "Kokkos::Serial: sync_wait") and (is an object whose given field is equal to 1), is a variant<> with value of type 'Kokkos::utils::callbacks::DeallocateDataEvent' and the value (is an object whose given field is an object whose given field is equal to "scratch"))
  Actual: { ('Kokkos::utils::callbacks::AllocateDataEvent(index = 2)' with value AllocateDataEvent: {name = "scratch", space = "Host", ptr = 0x5b3ac3e77500, size = 24}), ('Kokkos::utils::callbacks::BeginParallelForEvent(index = 1)' with value BeginParallelForEvent: {name = "Kokkos::View::initialization [scratch] via memset", dev_id = 1, event_id = 0}), ('Kokkos::utils::callbacks::BeginParallelForEvent(index = 1)' with value BeginParallelForEvent: {name = "Kokkos::Serial: bulk", dev_id = 1, event_id = 1}), ('Kokkos::utils::callbacks::BeginFenceEvent(index = 0)' with value BeginFenceEvent: {name = "Kokkos::Serial: schedule_from", dev_id = 1, event_id = 2}), ('Kokkos::utils::callbacks::BeginParallelForEvent(index = 1)' with value BeginParallelForEvent: {name = "Kokkos::Serial: bulk", dev_id = 1, event_id = 3}), ('Kokkos::utils::callbacks::BeginFenceEvent(index = 0)' with value BeginFenceEvent: {name = "Kokkos::Serial: sync_wait", dev_id = 1, event_id = 4}) }, does not contain in order an element that is a variant<> with value of type 'Kokkos::utils::callbacks::DeallocateDataEvent' and the value (is an object whose given field is an object whose given field is equal to "scratch")

[  FAILED  ] LetValueTest.scoped_allocation (4 ms)
```

And here is a `bash` script to run until it fails:
```bash
set -ex

TARGET=tests_execution_space_let_value.SERIAL

PRESET=gnu-OpenMP

cmake --build --preset=$PRESET -j8 --target=$TARGET

EXECUTABLE=build-with-$PRESET/tests/execution_space/$TARGET

while $EXECUTABLE ;
do
    echo "trying again"
done
```