### PR TITLE
parallel-for: don't store any label if none given

### DIFF
--- a/kokkos-execution/execution_space/bulk.hpp
+++ b/kokkos-execution/execution_space/bulk.hpp
@@ -16,9 +16,11 @@ struct TransformSenderFor<stdexec::bulk_t> {
     template <typename Env, typename Data, typename Sndr>
     using trnsfrmd_sndr_t = ParallelForSender<
         Sndr,
-        std::string_view,
-        typename Kokkos::Execution::Impl::bulk_traits<Data>::functor_t,
-        Kokkos::RangePolicy<exec_of_t<Sndr, Env>>
+        Impl::ParallelForData<
+            typename Kokkos::Execution::Impl::bulk_traits<Data>::functor_t,
+            Kokkos::RangePolicy<exec_of_t<Sndr, Env>>,
+            Impl::Label
+        >
     >;
 
     template <typename Env, Kokkos::Execution::Impl::has_parallel_policy Data, typename Sndr>
@@ -40,7 +42,7 @@ struct TransformSenderFor<stdexec::bulk_t> {
 
         return trnsfrmd_sndr_t<Env, Data, Sndr>{
             parallel_for_t{},
-            {{Impl::dispatch_label<exec_of_t<Sndr, Env>, ": bulk">(),
+            {{{std::string(Impl::dispatch_label<exec_of_t<Sndr, Env>, ": bulk">())},
               stdexec::__forward_like<Data>(functor),
               Kokkos::RangePolicy<exec_of_t<Sndr, Env>>(schd.state->exec, 0, shape)}},
             std::forward<Sndr>(sndr)};

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -13,18 +13,18 @@
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
-template <typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::__is_instance_of<Impl::ParallelForData> Data>
 struct ParallelForClosure {
-    using policy_t = ExecPolicy;
+    using policy_t = typename Data::policy_t;
     using execution_space = typename policy_t::execution_space;
 
-    Kokkos::Execution::Impl::ParallelForData<Label, Functor, policy_t> data;
+    Data data;
 
     void execute() const & {
-        if constexpr (std::convertible_to<Label, std::string>) {
+        if constexpr (Impl::labeled<Data>) {
             Kokkos::parallel_for(data.label, data.policy, data.functor);
         } else {
-            Kokkos::parallel_for(std::string{data.label}, data.policy, data.functor);
+            Kokkos::parallel_for(data.policy, data.functor);
         }
     }
 
@@ -33,11 +33,11 @@ struct ParallelForClosure {
     }
 };
 
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::sender Sndr, stdexec::__is_instance_of<Impl::ParallelForData> Data>
 struct ParallelForSender {
     using sender_concept = stdexec::sender_tag;
 
-    using closure_t = ParallelForClosure<Label, Functor, ExecPolicy>;
+    using closure_t = ParallelForClosure<Data>;
     using execution_space = typename closure_t::execution_space;
 
     parallel_for_t tag;
@@ -59,12 +59,7 @@ struct ParallelForSender {
 template <>
 struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
     template <typename Env, typename Data, typename Sndr>
-    using trnsfrmd_sndr_t = ParallelForSender<
-        Sndr,
-        typename std::remove_cvref_t<Data>::label_t,
-        typename std::remove_cvref_t<Data>::functor_t,
-        typename std::remove_cvref_t<Data>::policy_t
-    >;
+    using trnsfrmd_sndr_t = ParallelForSender<Sndr, std::remove_cvref_t<Data>>;
 
     template <typename Env, typename Data, typename Sndr>
     requires stdexec::__sends<stdexec::set_value_t, Sndr, Env>
@@ -75,25 +70,35 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
                  typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t&&,
                  Sndr&&
         >) {
-        auto [label, functor, policy] = std::forward<Data>(data);
-
-        auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
+        using sndr_t = trnsfrmd_sndr_t<Env, Data, Sndr>;
 
         //! Only the execution space instance, not its type, can be bound lately.
         static_assert(
-            std::same_as<
-                typename decltype(schd)::execution_space,
-                typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t::execution_space
-            >,
+            std::same_as<exec_of_t<Sndr, Env>, typename sndr_t::closure_t::execution_space>,
             "The policy's execution space type must be the same as the completion scheduler's execution space type.");
 
-        return trnsfrmd_sndr_t<Env, Data, Sndr>{
+        auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
+
+        typename std::remove_cvref_t<Data>::policy_t policy(
+            Kokkos::Impl::PolicyUpdate{}, stdexec::__forward_like<Data>(data.policy), schd.state->exec);
+
+        return sndr_t{
             parallel_for_t{},
-            {{std::move(label),
-              std::move(functor),
-              typename std::remove_cvref_t<Data>::policy_t(
-                  Kokkos::Impl::PolicyUpdate{}, std::move(policy), schd.state->exec)}},
+            make_closure<typename sndr_t::closure_t>(std::forward<Data>(data), std::move(policy)),
             std::forward<Sndr>(sndr)};
+    }
+
+   private:
+    template <typename Clsr, typename Data, typename Policy>
+    static auto make_closure(Data&& data, Policy&& policy) -> Clsr { // NOLINT(cppcoreguidelines-missing-std-forward)
+        if constexpr (Impl::labeled<std::remove_cvref_t<Data>>) {
+            return Clsr{
+                Impl::Label{stdexec::__forward_like<Data>(data.label)},
+                stdexec::__forward_like<Data>(data.functor),
+                std::forward<Policy>(policy)};
+        } else {
+            return Clsr{stdexec::__forward_like<Data>(data.functor), std::forward<Policy>(policy)};
+        }
     }
 };
 
@@ -103,9 +108,9 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
 namespace stdexec {
 
 //! See also https://cor3ntin.github.io/posts/clang21/#__builtin_structured_binding_size.
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <stdexec::sender Sndr, typename Data>
 inline constexpr auto __structured_binding_size_v< // NOLINT(bugprone-reserved-identifier)
-    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Label, Functor, ExecPolicy>
+    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Data>
 > = 3;
 
 } // namespace stdexec

--- a/kokkos-execution/execution_space/then.hpp
+++ b/kokkos-execution/execution_space/then.hpp
@@ -28,7 +28,8 @@ struct TransformSenderFor<stdexec::then_t> {
     using policy_t = Kokkos::RangePolicy<exec_of_t<Sndr, Env>, Kokkos::LaunchBounds<1>>;
 
     template <typename Env, typename Functor, typename Sndr>
-    using trnsfrmd_sndr_t = ParallelForSender<Sndr, std::string_view, ThenWrapper<Functor>, policy_t<Sndr, Env>>;
+    using trnsfrmd_sndr_t =
+        ParallelForSender<Sndr, Impl::ParallelForData<ThenWrapper<Functor>, policy_t<Sndr, Env>, Impl::Label>>;
 
     template <typename Env, typename Functor, typename Sndr>
     requires stdexec::__sends<stdexec::set_value_t, Sndr, Env>
@@ -43,7 +44,7 @@ struct TransformSenderFor<stdexec::then_t> {
 
         return trnsfrmd_sndr_t<Env, Functor, Sndr>{
             parallel_for_t{},
-            {{Impl::dispatch_label<exec_of_t<Sndr, Env>, ": then">(),
+            {{{std::string(Impl::dispatch_label<exec_of_t<Sndr, Env>, ": then">())},
               ThenWrapper<Functor>{std::forward<Functor>(functor)},
               policy_t<Sndr, Env>(schd.state->exec, 0, 1)}},
             std::forward<Sndr>(sndr)};

--- a/kokkos-execution/parallel_for.hpp
+++ b/kokkos-execution/parallel_for.hpp
@@ -9,8 +9,13 @@ namespace Kokkos::Execution {
 
 namespace Impl {
 
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <typename Functor, Kokkos::ExecutionPolicy Policy, typename... Mixins>
+struct ParallelForData;
+
+template <stdexec::sender Sndr, stdexec::__is_instance_of<ParallelForData> Data>
 struct ParallelForSender;
+
+struct Label;
 
 } // namespace Impl
 
@@ -23,7 +28,7 @@ struct parallel_for_t {
 
     template <typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
     constexpr auto operator()(ExecPolicy policy, Functor functor) const {
-        return this->operator()("", std::move(policy), std::move(functor));
+        return stdexec::__closure(*this, std::move(policy), std::move(functor));
     }
 
     template <typename Functor, std::integral T>
@@ -38,37 +43,54 @@ struct parallel_for_t {
     //! @warning May default to @c Kokkos::DefaultExecutionSpace, see https://github.com/kokkos/kokkos/blob/be33a115413f5eef8f82ff0ad1ca85c331edf153/core/src/Kokkos_Parallel.hpp#L155-L157.
     template <typename Functor, std::integral T>
     constexpr auto operator()(const T work_count, Functor functor) const {
-        return this->operator()("", work_count, std::move(functor));
+        using execution_space =
+            typename Kokkos::Impl::FunctorPolicyExecutionSpace<std::remove_cvref_t<Functor>, void>::execution_space;
+        using policy_t = Kokkos::RangePolicy<execution_space>;
+
+        return this->operator()(policy_t(0, work_count), std::move(functor));
     }
 
     template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
     constexpr auto operator()(Sndr&& sndr, std::string label, ExecPolicy policy, Functor functor) const {
-        return Impl::ParallelForSender<Sndr, std::string, Functor, ExecPolicy>(
-            {std::move(label), std::move(functor), std::move(policy)}, std::forward<Sndr>(sndr));
+        return Impl::ParallelForSender<Sndr, Impl::ParallelForData<Functor, ExecPolicy, Impl::Label>>(
+            {{std::move(label)}, std::move(functor), std::move(policy)}, std::forward<Sndr>(sndr));
+    }
+
+    template <stdexec::sender Sndr, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+    constexpr auto operator()(Sndr&& sndr, ExecPolicy policy, Functor functor) const {
+        return Impl::ParallelForSender<Sndr, Impl::ParallelForData<Functor, ExecPolicy>>(
+            {std::move(functor), std::move(policy)}, std::forward<Sndr>(sndr));
     }
 };
 
 namespace Impl {
 
-template <typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
-struct ParallelForData {
-    using label_t = Label;
+struct Label {
+    using label_t = std::string;
+
+    std::string label;
+};
+
+template <typename T>
+concept labeled = std::derived_from<T, Label>;
+
+template <typename Functor, Kokkos::ExecutionPolicy ExecPolicy, typename... Mixins>
+struct ParallelForData : public Mixins... {
     using functor_t = Functor;
     using policy_t = ExecPolicy;
 
-    label_t label;
     functor_t functor;
     policy_t policy;
 };
 
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
-struct ParallelForSender : stdexec::__tuple<parallel_for_t, ParallelForData<Label, Functor, ExecPolicy>, Sndr> {
+template <stdexec::sender Sndr, stdexec::__is_instance_of<ParallelForData> Data>
+struct ParallelForSender : stdexec::__tuple<parallel_for_t, Data, Sndr> {
     using sender_concept = stdexec::sender_tag;
 
-    using base_t = stdexec::__tuple<parallel_for_t, ParallelForData<Label, Functor, ExecPolicy>, Sndr>;
+    using base_t = stdexec::__tuple<parallel_for_t, Data, Sndr>;
 
     ParallelForSender(
-        ParallelForData<Label, Functor, ExecPolicy> data,
+        Data data,
         Sndr&& sndr) // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
         : base_t{parallel_for_t{}, std::move(data), std::forward<Sndr>(sndr)} {
     }

--- a/tests/execution_space/test_bulk.cpp
+++ b/tests/execution_space/test_bulk.cpp
@@ -52,9 +52,11 @@ consteval bool test_sndr_traits() {
                   bulk_sndr_t,
                   Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<
                       schd_sndr_t,
-                      std::string_view,
-                      functor_t,
-                      Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
+                      Kokkos::Execution::Impl::ParallelForData<
+                          functor_t,
+                          Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+                          Kokkos::Execution::Impl::Label
+                      >
                   >
     >);
 
@@ -120,18 +122,19 @@ constexpr bool test_op_state_passed_by_const_ref() {
     //! Connect the sender as a @c const reference.
     using op_state_from_sndr_const_ref_t = stdexec::connect_result_t<const sndr_t&, Tests::Utils::SinkReceiver>;
 
-    static_assert(std::same_as<
-                  op_state_from_sndr_const_ref_t,
-                  Kokkos::Execution::ExecutionSpaceImpl::OpState<
-                      const typename BulkTest::schedule_sender_t&,
-                      Tests::Utils::SinkReceiver,
-                      Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                          std::string_view,
-                          Tests::Utils::Functors::Labeled<'a'>,
-                          Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-                      >
-                  >
-    >);
+    static_assert(
+        std::same_as<
+            op_state_from_sndr_const_ref_t,
+            Kokkos::Execution::ExecutionSpaceImpl::OpState<
+                const typename BulkTest::schedule_sender_t&,
+                Tests::Utils::SinkReceiver,
+                Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
+                    Tests::Utils::Functors::Labeled<'a'>,
+                    Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+                    Kokkos::Execution::Impl::Label
+                >>
+            >
+        >);
 
     return true;
 }

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -142,11 +142,11 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
     using then_rcvr_t =
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             Kokkos::Execution::Impl::SyncWait::Receiver<host_execution_space>,
-            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                std::string_view,
+            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'h'>>,
-                Kokkos::RangePolicy<host_execution_space, Kokkos::LaunchBounds<1>>
-            >
+                Kokkos::RangePolicy<host_execution_space, Kokkos::LaunchBounds<1>>,
+                Kokkos::Execution::Impl::Label
+            >>
         >>;
     static_assert(std::same_as<decltype(op_state.inner_opstate.rcvr.rcvr.rcvr), then_rcvr_t>);
     static_assert(
@@ -183,11 +183,11 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
     using then_sfrom_con_h_then_rcvr_t =
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             sfrom_con_h_then_rcvr_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                std::string_view,
+            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'B'>>,
-                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
-            >
+                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>,
+                Kokkos::Execution::Impl::Label
+            >>
         >>;
     static_assert(
         std::same_as<decltype(op_state.inner_opstate.inner_opstate.rcvr.rcvr.rcvr), then_sfrom_con_h_then_rcvr_t>);
@@ -234,11 +234,11 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
     using then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t =
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
             sfrom_con_B_then_sfrom_con_h_then_rcvr_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                std::string_view,
+            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'A'>>,
-                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
-            >
+                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>,
+                Kokkos::Execution::Impl::Label
+            >>
         >>;
     static_assert(std::same_as<
                   decltype(op_state.inner_opstate.inner_opstate.inner_opstate.rcvr),

--- a/tests/execution_space/test_operation_state.cpp
+++ b/tests/execution_space/test_operation_state.cpp
@@ -28,7 +28,9 @@ consteval bool test_op_state_traits() {
     //! Parallel for closure.
     using functor_t = Tests::Utils::Functors::SumIndices<typename OpStateTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using clsr_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<std::string, functor_t, policy_t>;
+    using clsr_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
+        Kokkos::Execution::Impl::ParallelForData<functor_t, policy_t, Kokkos::Execution::Impl::Label>
+    >;
 
     //! Receiver.
     using rcvr_t = Tests::Utils::SinkReceiver;
@@ -67,18 +69,19 @@ constexpr bool test_op_state_passed_by_const_ref() {
     //! Connect the sender as a @c const reference.
     using op_state_from_sndr_const_ref_t = stdexec::connect_result_t<const sndr_t&, Tests::Utils::SinkReceiver>;
 
-    static_assert(std::same_as<
-                  op_state_from_sndr_const_ref_t,
-                  Kokkos::Execution::ExecutionSpaceImpl::OpState<
-                      const typename OpStateTest::schedule_sender_t&,
-                      Tests::Utils::SinkReceiver,
-                      Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                          std::string,
-                          Tests::Utils::Functors::Labeled<'a'>,
-                          Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-                      >
-                  >
-    >);
+    static_assert(
+        std::same_as<
+            op_state_from_sndr_const_ref_t,
+            Kokkos::Execution::ExecutionSpaceImpl::OpState<
+                const typename OpStateTest::schedule_sender_t&,
+                Tests::Utils::SinkReceiver,
+                Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
+                    Tests::Utils::Functors::Labeled<'a'>,
+                    Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+                    Kokkos::Execution::Impl::Label
+                >>
+            >
+        >);
 
     return true;
 }
@@ -91,11 +94,12 @@ static_assert(test_op_state_passed_by_const_ref());
  */
 template <stdexec::receiver Rcvr>
 consteval bool test_delegate_completion_with_event() {
-    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string_view,
-        Tests::Utils::Functors::Labeled<'a'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
+    using closure_t =
+        Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
+            Tests::Utils::Functors::Labeled<'a'>,
+            Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+            Kokkos::Execution::Impl::Label
+        >>;
     using opstate_t =
         Kokkos::Execution::ExecutionSpaceImpl::OpState<typename OpStateTest::schedule_sender_t, Rcvr, closure_t>;
     using opstate_base_t = Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<Rcvr, closure_t>;
@@ -133,8 +137,14 @@ TEST_F(OpStateTest, construct_query_and_start) {
 
     const context_t esc{exec};
 
-    Kokkos::Execution::Impl::ParallelForData pfor_data{
-        "hello from pfor", Tests::Utils::Functors::SumIndices{.data = witness}, Kokkos::RangePolicy(exec, 2, size)};
+    using functor_t = Tests::Utils::Functors::SumIndices<view_s_t>;
+
+    Kokkos::Execution::Impl::ParallelForData<
+        functor_t,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >
+        pfor_data{{"hello from pfor"}, functor_t{.data = witness}, Kokkos::RangePolicy(exec, 2, size)};
     Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure clsr{.data = std::move(pfor_data)};
 
     auto op_state = Kokkos::Execution::ExecutionSpaceImpl::OpState{
@@ -162,16 +172,16 @@ consteval bool test_op_state_flattened_from_two() {
 
     using op_state_t = stdexec::connect_result_t<sndr_t&&, Tests::Utils::SinkReceiver>;
 
-    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'a'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
-    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
+    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'b'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
 
     static_assert(std::same_as<
                   op_state_t,
@@ -209,21 +219,21 @@ consteval bool test_op_state_flattened_from_three() {
 
     using op_state_t = stdexec::connect_result_t<sndr_t&&, Tests::Utils::SinkReceiver>;
 
-    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'a'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
-    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
+    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'b'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
-    using clsr_2_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
+    using clsr_2_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'c'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
 
     static_assert(std::same_as<
                   op_state_t,
@@ -251,7 +261,6 @@ consteval bool test_op_state_flattened_from_three_mixed_tags() {
         stdexec::bulk(
             Kokkos::Execution::parallel_for(
                 stdexec::schedule(std::declval<typename OpStateTest::context_t>().get_scheduler()),
-                "hello from pfor",
                 Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::IndexType<size_t>>(0, 10),
                 Tests::Utils::Functors::Labeled<'a'>{}),
             stdexec::par,
@@ -261,21 +270,20 @@ consteval bool test_op_state_flattened_from_three_mixed_tags() {
 
     using op_state_t = stdexec::connect_result_t<sndr_t&&, Tests::Utils::SinkReceiver>;
 
-    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string,
+    using clsr_0_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'a'>,
         Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::IndexType<size_t>>
-    >;
-    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string_view,
+    >>;
+    using clsr_1_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Tests::Utils::Functors::Labeled<'b'>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
-    >;
-    using clsr_2_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-        std::string_view,
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>,
+        Kokkos::Execution::Impl::Label
+    >>;
+    using clsr_2_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<Kokkos::Execution::Impl::ParallelForData<
         Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'c'>>,
-        Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
-    >;
+        Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>,
+        Kokkos::Execution::Impl::Label
+    >>;
 
     static_assert(std::same_as<
                   op_state_t,

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -43,16 +43,16 @@ class ParallelForTest
  * @test Check traits of sender returned by @ref Kokkos::Execution::parallel_for either uncustomized
  *       or customized for @ref Kokkos::Execution::ExecutionSpaceContext.
  */
-template <template <typename, typename, typename, typename> class SndrAdptr>
+template <template <typename, typename> class SndrAdptr>
 consteval bool test_sndr_traits() {
     //! Schedule sender.
     using schd_sndr_t = typename ParallelForTest::schedule_sender_t;
 
     //! Parallel for sender.
-    using label_t = std::string;
     using functor_t = Tests::Utils::Functors::SumIndices<typename ParallelForTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using pfor_sndr_t = SndrAdptr<schd_sndr_t, label_t, functor_t, policy_t>;
+    using pfor_data_t = Kokkos::Execution::Impl::ParallelForData<functor_t, policy_t, Kokkos::Execution::Impl::Label>;
+    using pfor_sndr_t = SndrAdptr<schd_sndr_t, pfor_data_t>;
 
     //! Models the execution space completing sender concept.
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::execution_space_completing_sender<pfor_sndr_t>);
@@ -86,7 +86,7 @@ consteval bool test_sndr_traits() {
 
     static_assert(std::same_as<
                   stdexec::transform_sender_result_t<pfor_sndr_t, stdexec::env_of_t<Tests::Utils::SinkReceiver>>,
-                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>
+                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, pfor_data_t>
     >);
 
 //! @bug https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/Kokkos_View.hpp#L697
@@ -100,7 +100,7 @@ consteval bool test_sndr_traits() {
      */
     static_assert(!std::is_nothrow_move_constructible_v<typename ParallelForTest::view_s_t>);
     static_assert(!std::is_nothrow_move_constructible_v<functor_t>);
-    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<label_t, functor_t, policy_t>;
+    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<pfor_data_t>;
     static_assert(!std::is_nothrow_move_constructible_v<closure_t>);
     static_assert(!stdexec::__nothrow_connectable<pfor_sndr_t, Tests::Utils::SinkReceiver>);
 #else
@@ -119,18 +119,15 @@ consteval bool test_sndr_decomposition() {
     using schd_sndr_t = typename ParallelForTest::schedule_sender_t;
 
     //! Parallel for sender.
-    using label_t = std::string;
     using functor_t = Tests::Utils::Functors::SumIndices<typename ParallelForTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using pfor_sndr_t = Kokkos::Execution::Impl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>;
+    using pfor_data_t = Kokkos::Execution::Impl::ParallelForData<functor_t, policy_t, Kokkos::Execution::Impl::Label>;
+    using pfor_sndr_t = Kokkos::Execution::Impl::ParallelForSender<schd_sndr_t, pfor_data_t>;
 
     //! Is decomposable into the expected algorithm tag, data, and child sender.
     static_assert(stdexec::__sender_for<pfor_sndr_t, Kokkos::Execution::parallel_for_t>);
 
-    static_assert(std::same_as<
-                  stdexec::__data_of<pfor_sndr_t>,
-                  Kokkos::Execution::Impl::ParallelForData<label_t, functor_t, policy_t>
-    >);
+    static_assert(std::same_as<stdexec::__data_of<pfor_sndr_t>, pfor_data_t>);
 
     static_assert(stdexec::__nbr_children_of<pfor_sndr_t> == 1);
     static_assert(std::same_as<stdexec::__child_of<pfor_sndr_t>, schd_sndr_t>);
@@ -151,7 +148,8 @@ template <typename ViewType, bool ExpectNoThrowMoveConstructible>
 consteval bool test_closure_traits() {
     using functor_t = Tests::Utils::Functors::SumIndices<ViewType>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<std::string, functor_t, policy_t>;
+    using pfor_data_t = Kokkos::Execution::Impl::ParallelForData<functor_t, policy_t, Kokkos::Execution::Impl::Label>;
+    using closure_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<pfor_data_t>;
 
     //! Models the @ref Kokkos::Execution::ExecutionSpaceImpl::Closure concept.
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::Closure<closure_t>);


### PR DESCRIPTION
Today, it's the label but later it could be any sort of property.

So this PR is an attempt at making the parallel-for data more flexible.

Also, the final operation state will be a few bytes smaller if no label is necessary ( :zap: ).

> Note that the `std::string_view` tweak for the label is abandoned because ultimately Kokkos wants a `std::string`. The label is therefore either not present, or is unconditionally a `std::string`.