### PR TITLE
ExecutionSpace: simplify sequence matchers

### DIFF
--- a/tests/execution_space/test_inter_op.cpp
+++ b/tests/execution_space/test_inter_op.cpp
@@ -60,7 +60,7 @@ TEST_F(InterOpTest, transition_to_inline_scheduler) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -92,7 +92,7 @@ TEST_F(InterOpTest, transition_from_inline_scheduler) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -127,7 +127,7 @@ TEST_F(InterOpTest, transition_from_inline_scheduler_and_back) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -161,7 +161,7 @@ TEST_F(InterOpTest, transition_to_static_thread_pool) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -195,7 +195,7 @@ TEST_F(InterOpTest, transition_from_static_thread_pool) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -232,7 +232,7 @@ TEST_F(InterOpTest, transition_from_static_thread_pool_and_back) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
@@ -269,7 +269,7 @@ TEST_F(InterOpTest, transition_to_static_thread_pool_and_back) {
             stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
         });
 
-    EXPECT_THAT(
+    ASSERT_THAT(
         recorded_events,
         testing::ElementsAre(
             MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),

--- a/tests/execution_space/test_sync_wait.cpp
+++ b/tests/execution_space/test_sync_wait.cpp
@@ -1,4 +1,5 @@
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
+#include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
 #include "tests/utils/callback_matchers.hpp"
 #include "tests/utils/execution_space_context.hpp"
@@ -18,40 +19,47 @@
 
 namespace Tests::ExecutionSpaceImpl {
 
-using ExecutionSpaceContextTest = Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>;
+using namespace Kokkos::utils::callbacks;
+
+class SyncWaitTest
+    : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>
+    , public Kokkos::utils::tests::scoped::callbacks::Manager {
+   public:
+    using recorder_listener_t = RecorderListener<
+        EventDiscardMatcher<TEST_EXECUTION_SPACE>,
+        BeginFenceEvent,
+        Kokkos::Execution::Impl::RecordEvent,
+        Kokkos::Execution::Impl::WaitEvent
+    >;
+};
 
 /**
  * @test Ensure that @c sync_wait is properly customized.
  *
  * Improperly customized @c sync_wait should result in a missing synchronization.
  */
-TEST_F(ExecutionSpaceContextTest, sync_wait) {
+TEST_F(SyncWaitTest, sync_wait) {
     const context_t esc{exec};
 
-    auto chain = stdexec::schedule(esc.get_scheduler());
-
-    Kokkos::utils::callbacks::Manager::initialize();
+    auto sndr = stdexec::schedule(esc.get_scheduler());
 
     ASSERT_THAT(
-        Kokkos::utils::callbacks::RecorderListener<Kokkos::utils::callbacks::BeginFenceEvent>::record(
-            [chain = std::move(chain)]() mutable {                       // NOLINT(performance-move-const-arg)
-                const auto value = stdexec::sync_wait(std::move(chain)); // NOLINT(performance-move-const-arg)
-                static_assert(std::same_as<decltype(value), const std::optional<std::tuple<>>>);
-                ASSERT_TRUE(value.has_value());
-            }),
+        recorder_listener_t::record([sndr = std::move(sndr)]() mutable { // NOLINT(performance-move-const-arg)
+            const auto value = stdexec::sync_wait(std::move(sndr));      // NOLINT(performance-move-const-arg)
+            static_assert(std::same_as<decltype(value), const std::optional<std::tuple<>>>);
+            ASSERT_TRUE(value.has_value());
+        }),
         testing::ElementsAre(MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
-
-    Kokkos::utils::callbacks::Manager::finalize();
 }
 
 //! @test Check that @ref Kokkos::Execution::ExecutionSpaceImpl::SyncWait properly rethrows if needed.
-TEST_F(ExecutionSpaceContextTest, rethrows) {
+TEST_F(SyncWaitTest, rethrows) {
     const context_t esc{exec};
 
-    auto chain = stdexec::schedule(esc.get_scheduler()) | stdexec::then(Tests::Utils::Functors::ThrowsWhenCopied{});
+    auto sndr = stdexec::schedule(esc.get_scheduler()) | stdexec::then(Tests::Utils::Functors::ThrowsWhenCopied{});
 
     ASSERT_THAT(
-        Tests::Utils::Functors::MutableMoveToSyncWait{.sndr = std::move(chain)},
+        Tests::Utils::Functors::MutableMoveToSyncWait{.sndr = std::move(sndr)},
         testing::ThrowsMessage<std::runtime_error>(testing::StrEq("ThrowsWhenCopied: Throwing in copy constructor!")));
 }
 

--- a/tests/execution_space/test_transfer_when_all.cpp
+++ b/tests/execution_space/test_transfer_when_all.cpp
@@ -83,23 +83,25 @@ TEST_F(TransferWhenAllTest, Y) {
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
-    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 6);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")));
-        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait")));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
-                MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
+        ASSERT_THAT(recorded_events, [&]() {
+            if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
+                    MATCHER_FOR_RECORD_EVENT(exec_B),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait")));
+            } else {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait")));
+            }
+        }());
     }
 
     ASSERT_EQ(data(), 3);

--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -78,20 +78,20 @@ TEST_F(WhenAllTest, single_branch) {
     const auto recorded_events = recorder_listener_t::record(
         [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
 
-    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 3);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
-    } else {
-        /// Because the sender returned by @c stdexec::when_all is not an execution space completing sender,
-        /// the default implementation of @c stdexec::sync_wait is used.
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
+    /// Because the sender returned by @c stdexec::when_all is not an execution space completing sender,
+    /// the default implementation of @c stdexec::sync_wait is used.
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
-    }
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
+        } else {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")));
+        }
+    }());
 
     ASSERT_EQ(data(), 1);
 }
@@ -180,22 +180,22 @@ TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
     const auto recorded_events = recorder_listener_t::record(
         [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
 
-    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 5);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-    } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        } else {
+            return testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
-    }
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        }
+    }());
 
     ASSERT_EQ(data(), 3);
 }
@@ -275,23 +275,26 @@ TEST_F(WhenAllTest, two_branches_followed_by_self) {
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
-    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 6);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait")));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
-                MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait"))));
+        ASSERT_THAT(recorded_events, [&]() {
+            if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                    MATCHER_FOR_RECORD_EVENT(exec_B),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait")));
+
+            } else {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec_B, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec_A, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "sync_wait")));
+            }
+        }());
     }
 
     ASSERT_EQ(data(), 3);
@@ -336,23 +339,25 @@ TEST_F(WhenAllTest, two_branches_host_device_followed_by_device) {
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
-    } else if constexpr (Kokkos::Execution::Impl::support_events<host_execution_space>) {
-        ASSERT_EQ(recorded_events.size(), 6);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_h));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+        ASSERT_THAT(recorded_events, [&]() {
+            if constexpr (Kokkos::Execution::Impl::support_events<host_execution_space>) {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
+                    MATCHER_FOR_RECORD_EVENT(exec_h),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)),
+                    MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+            } else {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "after dispatch")),
+                    MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+            }
+        }());
     }
 
     ASSERT_EQ(data(), 3);
@@ -386,22 +391,22 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
     const auto recorded_events = recorder_listener_t::record(
         [sndr = std::move(sndr)]() mutable { stdexec::sync_wait(std::move(sndr)); });
 
-    if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 5);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-    } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        } else {
+            return testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
-    }
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        }
+    }());
 
     ASSERT_EQ(data(), 4);
 }
@@ -484,29 +489,31 @@ TEST_F(WhenAllTest, nested_when_all_with_independent_branch) {
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
                 MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "after dispatch"))));
-    } else if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-        ASSERT_EQ(recorded_events.size(), 10);
-        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"));
-        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"));
-        ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_B));
-        ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"));
-        ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_RECORD_EVENT(exec_C));
-        ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)));
-        ASSERT_THAT(recorded_events.at(6), MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"));
-        ASSERT_THAT(recorded_events.at(7), MATCHER_FOR_RECORD_EVENT(exec_A));
-        ASSERT_THAT(recorded_events.at(8), MATCHER_FOR_WAIT_EVENT(recorded_events.at(4)));
-        ASSERT_THAT(recorded_events.at(9), MATCHER_FOR_WAIT_EVENT(recorded_events.at(7)));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"),
-                MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
-                MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "after dispatch"))));
+        ASSERT_THAT(recorded_events, [&]() {
+            if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"),
+                    MATCHER_FOR_RECORD_EVENT(exec_B),
+                    MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
+                    MATCHER_FOR_RECORD_EVENT(exec_C),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"),
+                    MATCHER_FOR_RECORD_EVENT(exec_A),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(4)),
+                    MATCHER_FOR_WAIT_EVENT(recorded_events.at(7)));
+            } else {
+                return testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, "'A'"),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, "'B'"),
+                    MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec_B, "after dispatch")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, "'D'"),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "after dispatch")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_C, "'C'"),
+                    MATCHER_FOR_BEGIN_FENCE(exec_C, dispatch_label(exec_C, "after dispatch")));
+            }
+        }());
     }
 }
 


### PR DESCRIPTION
Extracted from:
- #117 