### PR TITLE
ExecutionSpace: get exec from receiver's scheduler in `ScheduleFromReceiver`

### DIFF
--- a/kokkos-execution/execution_space/continues_on.hpp
+++ b/kokkos-execution/execution_space/continues_on.hpp
@@ -20,10 +20,11 @@ struct FwdWithExec { };
 struct FwdWithoutExec { };
 
 //! Receiver for @c continues_on.
-template <stdexec::receiver Rcvr, typename FwdPolicy = FwdWithExec>
+template <stdexec::scheduler Schd, stdexec::receiver Rcvr, typename FwdPolicy = FwdWithExec>
 struct ContinuesOnReceiver {
     using receiver_concept = stdexec::receiver_t;
 
+    Schd schd;
     Rcvr rcvr;
 
     void set_value() && noexcept {
@@ -37,6 +38,11 @@ struct ContinuesOnReceiver {
 
     void set_stopped() && noexcept {
         stdexec::set_stopped(std::move(rcvr));
+    }
+
+    [[nodiscard]]
+    constexpr auto query(get_exec_t) const noexcept -> ExecutionSpaceRef<typename Schd::execution_space> {
+        return ExecutionSpaceRef<typename Schd::execution_space>{schd.state->exec};
     }
 
     [[nodiscard]]
@@ -58,42 +64,52 @@ struct ContinuesOnReceiver {
 };
 
 //! Sender for @c continues_on.
-template <stdexec::sender Sndr>
+template <stdexec::scheduler Schd, stdexec::sender Sndr>
 struct ContinuesOnSender {
     using sender_concept = stdexec::sender_t;
 
+    Schd schd;
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender)
 
-    template <
-        stdexec::receiver Rcvr,
-        typename FwdPolicy = std::conditional_t<
+    template <typename Rcvr>
+    static consteval auto select_fwd_policy() {
+        if constexpr (
             std::same_as<
                 stdexec::__detail::__completing_domain_t<stdexec::set_value_t, Sndr, stdexec::env_of_t<Rcvr>>,
                 Domain
             >
-                || has_when_all_child_with_at_least_one_child_completing_on_v<
-                    stdexec::set_value_t,
-                    Domain,
-                    Sndr,
-                    stdexec::env_of_t<Rcvr>
-                >
-                || has_fork_join_child_with_at_least_one_child_completing_on_v<
-                    stdexec::set_value_t,
-                    Domain,
-                    Sndr,
-                    stdexec::env_of_t<Rcvr>
-                >,
-            FwdWithExec,
-            FwdWithoutExec
-        >
-    >
-    auto connect(Rcvr rcvr) && noexcept(std::is_nothrow_move_constructible_v<Rcvr>)
-        -> stdexec::connect_result_t<Sndr, ContinuesOnReceiver<Rcvr, FwdPolicy>> {
-        using recv_t = ContinuesOnReceiver<Rcvr, FwdPolicy>;
+            || has_when_all_child_with_at_least_one_child_completing_on_v<
+                stdexec::set_value_t,
+                Domain,
+                Sndr,
+                stdexec::env_of_t<Rcvr>
+            >
+            || has_fork_join_child_with_at_least_one_child_completing_on_v<
+                stdexec::set_value_t,
+                Domain,
+                Sndr,
+                stdexec::env_of_t<Rcvr>
+            >) {
+            return FwdWithExec{};
+        } else {
+            return FwdWithoutExec{};
+        }
+    }
 
-        return stdexec::connect(std::forward<Sndr>(sndr), recv_t{.rcvr = std::move(rcvr)});
+    template <typename Rcvr>
+    using fwd_policy_t = decltype(select_fwd_policy<Rcvr>());
+
+    template <typename Rcvr>
+    using rcvr_t = ContinuesOnReceiver<Schd, Rcvr, fwd_policy_t<Rcvr>>;
+
+    template <stdexec::receiver Rcvr>
+    auto connect(Rcvr rcvr) && noexcept(
+        std::is_nothrow_constructible_v<rcvr_t<Rcvr>, Schd&&, Rcvr&&>
+        && stdexec::__nothrow_connectable<Sndr&&, rcvr_t<Rcvr>>) -> stdexec::connect_result_t<Sndr&&, rcvr_t<Rcvr>> {
+        return stdexec::connect(
+            std::forward<Sndr>(sndr), rcvr_t<Rcvr>{.schd = std::forward<Schd>(schd), .rcvr = std::move(rcvr)});
     }
 
     KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
@@ -102,9 +118,9 @@ struct ContinuesOnSender {
 template <>
 struct TransformSenderFor<stdexec::continues_on_t> {
     template <typename Env, stdexec::__is_instance_of<Scheduler> Schd, stdexec::sender Sndr>
-    auto operator()(const Env&, stdexec::continues_on_t, Schd&&, Sndr&& sndr) const
-        noexcept(std::is_nothrow_constructible_v<ContinuesOnSender<Sndr>, Sndr&&>) {
-        return ContinuesOnSender<Sndr>{.sndr = std::forward<Sndr>(sndr)};
+    auto operator()(const Env&, stdexec::continues_on_t, Schd&& schd, Sndr&& sndr) const
+        noexcept(std::is_nothrow_constructible_v<ContinuesOnSender<Schd, Sndr>, Schd&&, Sndr&&>) {
+        return ContinuesOnSender<Schd, Sndr>{.schd = std::forward<Schd>(schd), .sndr = std::forward<Sndr>(sndr)};
     }
 };
 

--- a/kokkos-execution/execution_space/get_exec.hpp
+++ b/kokkos-execution/execution_space/get_exec.hpp
@@ -29,6 +29,8 @@ inline constexpr get_exec_t get_exec{};
  */
 template <Kokkos::ExecutionSpace Exec>
 struct ExecutionSpaceRef {
+    using execution_space = Exec;
+
     Exec const * m_exec_ptr;
 
     explicit constexpr ExecutionSpaceRef(const Exec& exec) noexcept

--- a/kokkos-execution/execution_space/schedule_from.hpp
+++ b/kokkos-execution/execution_space/schedule_from.hpp
@@ -23,15 +23,13 @@ struct ScheduleFromReceiver {
     void set_value() && noexcept {
         //! If the downstream receiver is our customization of @c continues_on and it shares the same execution space instance, skip the fence.
         const bool skip = [&]() {
-            if constexpr (stdexec::__is_instance_of<Rcvr, ContinuesOnReceiver>) {
-                if constexpr (stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, get_exec_t>) {
-                    if constexpr (
-                        std::same_as<
-                            std::remove_cvref_t<decltype(get_exec(stdexec::get_env(rcvr)).get())>,
-                            typename Schd::execution_space
-                        >) {
-                        return schd.state->exec == get_exec(stdexec::get_env(rcvr)).get();
-                    }
+            if constexpr (stdexec::__queryable_with<Rcvr, get_exec_t>) {
+                if constexpr (
+                    std::same_as<
+                        typename stdexec::__query_result_t<Rcvr, get_exec_t>::execution_space,
+                        typename Schd::execution_space
+                    >) {
+                    return schd.state->exec == rcvr.query(get_exec).get();
                 }
             }
             return false;

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -156,7 +156,10 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         exec_h);
 
     //! Our customization of @c continues_on forwards the environment.
-    using con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<then_rcvr_t>;
+    using con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<
+        Kokkos::Execution::ExecutionSpaceImpl::Scheduler<host_execution_space>,
+        then_rcvr_t
+    >;
     static_assert(std::same_as<decltype(op_state.inner_opstate.rcvr.rcvr), con_h_then_rcvr_t>);
     static_assert(stdexec::__queryable_with<
                   stdexec::env_of_t<con_h_then_rcvr_t>,
@@ -202,7 +205,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         exec_B);
 
     using con_B_then_sfrom_con_h_then_rcvr_t =
-        Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<then_sfrom_con_h_then_rcvr_t>;
+        Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<scheduler_t, then_sfrom_con_h_then_rcvr_t>;
     static_assert(
         std::same_as<decltype(op_state.inner_opstate.inner_opstate.rcvr.rcvr), con_B_then_sfrom_con_h_then_rcvr_t>);
     static_assert(stdexec::__queryable_with<


### PR DESCRIPTION
Extracted from:
- #117 