### PR TITLE
sync(wait): towards a general execution space based sync wait (for graph too)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ target_sources(
             kokkos-execution/impl/HPX/event.hpp
             kokkos-execution/impl/sender_concepts.hpp
             kokkos-execution/impl/SYCL/event.hpp
+            kokkos-execution/impl/state.hpp
             kokkos-execution/impl/sync_wait.hpp
             kokkos-execution/utils/ignore_warnings.hpp
 )

--- a/kokkos-execution/execution_space.hpp
+++ b/kokkos-execution/execution_space.hpp
@@ -14,15 +14,11 @@
 #include "kokkos-execution/execution_space/scoped_region.hpp"
 #include "kokkos-execution/execution_space/sync_wait.hpp"
 #include "kokkos-execution/execution_space/then.hpp"
+#include "kokkos-execution/impl/state.hpp"
 
 namespace Kokkos::Execution {
 
 namespace ExecutionSpaceImpl {
-
-template <Kokkos::ExecutionSpace Exec>
-struct State {
-    Exec exec;
-};
 
 /**
  * @brief Scheduler for a @c Kokkos execution space.
@@ -70,7 +66,7 @@ struct Scheduler {
                 return {};
             }
 
-            State<Exec>* state;
+            Impl::State<Exec>* state;
         };
 
         template <stdexec::receiver_of<completion_signatures> Rcvr>
@@ -111,7 +107,7 @@ struct Scheduler {
     [[nodiscard]]
     friend bool operator==(const Scheduler&, const Scheduler&) noexcept = default;
 
-    State<Exec>* state;
+    Impl::State<Exec>* state;
 };
 
 } // namespace ExecutionSpaceImpl
@@ -125,7 +121,7 @@ struct Scheduler {
  */
 template <Kokkos::ExecutionSpace Exec>
 struct ExecutionSpaceContext {
-    using state_t = ExecutionSpaceImpl::State<Exec>;
+    using state_t = Impl::State<Exec>;
 
     state_t m_state;
 

--- a/kokkos-execution/execution_space/execution_space_fwd.hpp
+++ b/kokkos-execution/execution_space/execution_space_fwd.hpp
@@ -22,9 +22,6 @@ struct Scheduler;
 template <stdexec::scheduler Schd, stdexec::receiver Rcvr>
 struct ScheduleFromReceiver;
 
-template <Kokkos::ExecutionSpace Exec, typename... Values>
-struct SyncWaitReceiver;
-
 } // namespace Kokkos::Execution::ExecutionSpaceImpl
 
 #endif // KOKKOS_EXECUTION_EXECUTION_SPACE_EXECUTION_SPACE_FWD_HPP

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -13,6 +13,7 @@
 #include "kokkos-execution/impl/env.hpp"
 #include "kokkos-execution/impl/event.hpp"
 #include "kokkos-execution/impl/sender_concepts.hpp"
+#include "kokkos-execution/impl/sync_wait.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
@@ -39,7 +40,7 @@ concept Closure = requires(const Clsr& clsr) {
 template <stdexec::receiver Rcvr, typename OpState>
 struct RequiresSynchronization {
     static constexpr bool successor_handles_sync = stdexec::__is_instance_of<Rcvr, ScheduleFromReceiver>
-                                                || stdexec::__is_instance_of<Rcvr, SyncWaitReceiver>;
+                                                || stdexec::__is_instance_of<Rcvr, Impl::SyncWait::Receiver>;
 
     //! The synchronization will be handled by the successor.
     constexpr bool operator()(const OpState&) const noexcept requires(successor_handles_sync)

--- a/kokkos-execution/execution_space/sync_wait.hpp
+++ b/kokkos-execution/execution_space/sync_wait.hpp
@@ -1,89 +1,11 @@
 #ifndef KOKKOS_EXECUTION_EXECUTION_SPACE_SYNC_WAIT_HPP
 #define KOKKOS_EXECUTION_EXECUTION_SPACE_SYNC_WAIT_HPP
 
-#include "stdexec/execution.hpp"
-
 #include "kokkos-execution/execution_space/execution_space_fwd.hpp"
-
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/execution_space/sender_concepts.hpp"
 #include "kokkos-execution/impl/sync_wait.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
-
-//! Receiver for @c sync_wait.
-template <Kokkos::ExecutionSpace Exec, typename... Values>
-struct SyncWaitReceiver {
-    using receiver_concept = stdexec::receiver_t;
-
-    State<Exec> const * state;
-    Kokkos::Execution::Impl::State* runloop_state;
-    std::optional<std::tuple<Values...>>* result;
-
-    template <typename... Args>
-    void set_value(Args&&... args) && noexcept {
-        state->exec.fence(std::format("{}: sync_wait", Kokkos::Impl::TypeInfo<Exec>::name()));
-        result->emplace(std::forward<Args>(args)...);
-        runloop_state->loop.finish();
-    }
-
-    template <typename Error>
-    void set_error(Error&& err) && noexcept {
-        runloop_state->error = std::forward<Error>(err);
-        state->exec.fence(std::format("{}: sync_wait", Kokkos::Impl::TypeInfo<Exec>::name()));
-        runloop_state->loop.finish();
-    }
-
-    void set_stopped() noexcept {
-        state->exec.fence(std::format("{}: sync_wait", Kokkos::Impl::TypeInfo<Exec>::name()));
-        runloop_state->loop.finish();
-    }
-
-    //! Make others aware of which execution space instance it will synchronize.
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept
-        -> stdexec::__join_env_t<stdexec::prop<get_exec_t, ExecutionSpaceRef<Exec>>, Kokkos::Execution::Impl::env> {
-        return stdexec::__env::__join(
-            stdexec::prop{get_exec, ExecutionSpaceRef{state->exec}},
-            Kokkos::Execution::Impl::env{runloop_state->loop.get_scheduler()});
-    }
-};
-
-struct SyncWait {
-    /**
-     * According to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#spec-execution.senders.consumers.sync_wait,
-     * it has to return an engaged optional (on the value channel).
-     *
-     * @todo Make the @c noexcept specifier depend on the completion signatures of @p sndr.
-     */
-    template <stdexec::sender Sndr>
-    auto operator()(Sndr&& sndr) const noexcept(false)
-        -> std::optional<stdexec::__sync_wait::__value_tuple_for_t<Sndr>> {
-        Kokkos::Execution::Impl::State runloop_state;
-
-        auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), stdexec::env{});
-
-        using result_t = std::optional<stdexec::__sync_wait::__value_tuple_for_t<Sndr>>;
-
-        result_t result{};
-
-        auto op_state = stdexec::connect(
-            std::forward<Sndr>(sndr),
-            SyncWaitReceiver{
-                .state = std::move(schd.state),
-                .runloop_state = std::addressof(runloop_state),
-                .result = std::addressof(result)});
-
-        stdexec::start(op_state);
-
-        runloop_state.loop.run();
-
-        if (runloop_state.error)
-            std::rethrow_exception(std::move(runloop_state.error));
-
-        return result;
-    }
-};
 
 /**
  * @brief Customize @c sync_wait.
@@ -96,8 +18,8 @@ struct SyncWait {
 template <>
 struct ApplySenderFor<stdexec::sync_wait_t> {
     template <execution_space_completing_sender Sndr>
-    auto operator()(Sndr&& sndr) && noexcept(std::is_nothrow_invocable_v<SyncWait, Sndr&&>) {
-        return SyncWait{}(std::forward<Sndr>(sndr));
+    auto operator()(Sndr&& sndr) && noexcept(std::is_nothrow_invocable_v<Impl::SyncWait::SyncWait, Sndr&&>) {
+        return Impl::SyncWait::SyncWait{}(std::forward<Sndr>(sndr));
     }
 };
 

--- a/kokkos-execution/graph.hpp
+++ b/kokkos-execution/graph.hpp
@@ -6,15 +6,11 @@
 #include "Kokkos_Core.hpp"
 
 #include "kokkos-execution/graph/domain.hpp"
+#include "kokkos-execution/impl/state.hpp"
 
 namespace Kokkos::Execution {
 
 namespace GraphImpl {
-
-template <Kokkos::ExecutionSpace Exec>
-struct State {
-    Exec exec;
-};
 
 //!  Scheduler for a @c Kokkos::Experimental::Graph.
 template <Kokkos::ExecutionSpace Exec>
@@ -57,7 +53,7 @@ struct Scheduler {
                 return {};
             }
 
-            State<Exec>* state;
+            Impl::State<Exec>* state;
         };
 
         template <stdexec::receiver_of<completion_signatures> Rcvr>
@@ -98,7 +94,7 @@ struct Scheduler {
     [[nodiscard]]
     friend bool operator==(const Scheduler&, const Scheduler&) noexcept = default;
 
-    State<Exec>* state;
+    Impl::State<Exec>* state;
 };
 
 } // namespace GraphImpl
@@ -106,7 +102,7 @@ struct Scheduler {
 //! Execution context using @c Kokkos::Experimental::Graph under the hood.
 template <Kokkos::ExecutionSpace Exec>
 struct GraphContext {
-    using state_t = GraphImpl::State<Exec>;
+    using state_t = Impl::State<Exec>;
 
     state_t m_state;
 

--- a/kokkos-execution/impl/state.hpp
+++ b/kokkos-execution/impl/state.hpp
@@ -1,0 +1,15 @@
+#ifndef KOKKOS_EXECUTION_IMPL_STATE_HPP
+#define KOKKOS_EXECUTION_IMPL_STATE_HPP
+
+#include "Kokkos_Core.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+template <Kokkos::ExecutionSpace Exec>
+struct State {
+    Exec exec;
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_STATE_HPP

--- a/kokkos-execution/impl/sync_wait.hpp
+++ b/kokkos-execution/impl/sync_wait.hpp
@@ -1,9 +1,13 @@
 #ifndef KOKKOS_EXECUTION_IMPL_SYNC_WAIT_HPP
 #define KOKKOS_EXECUTION_IMPL_SYNC_WAIT_HPP
 
-#include "stdexec/execution.hpp"
+#include "kokkos-execution/stdexec.hpp"
 
-namespace Kokkos::Execution::Impl {
+#include "kokkos-execution/execution_space/get_exec.hpp"
+#include "kokkos-execution/impl/dispatch_label.hpp"
+#include "kokkos-execution/impl/state.hpp"
+
+namespace Kokkos::Execution::Impl::SyncWait {
 
 //! Inspired by https://github.com/NVIDIA/stdexec/blob/16076a81efa4477513e6ede9c2741fd034ecef99/include/stdexec/__detail/__sync_wait.hpp#L45-L65.
 struct env {
@@ -26,6 +30,84 @@ struct State {
     stdexec::run_loop loop;
 };
 
-} // namespace Kokkos::Execution::Impl
+//! Receiver for @c stdexec::sync_wait.
+template <Kokkos::ExecutionSpace Exec, typename... Values>
+struct Receiver {
+    using receiver_concept = stdexec::receiver_t;
+
+    static constexpr auto label = Impl::dispatch_label<Exec, ": sync_wait">();
+
+    Impl::State<Exec> const * state;
+    State* runloop_state;
+    std::optional<std::tuple<Values...>>* result;
+
+    template <typename... Args>
+    void set_value(Args&&... args) && noexcept {
+        state->exec.fence(std::string(label));
+        result->emplace(std::forward<Args>(args)...);
+        runloop_state->loop.finish();
+    }
+
+    template <typename Error>
+    void set_error(Error&& err) && noexcept {
+        runloop_state->error = std::forward<Error>(err);
+        state->exec.fence(std::string(label));
+        runloop_state->loop.finish();
+    }
+
+    void set_stopped() && noexcept {
+        state->exec.fence(std::string(label));
+        runloop_state->loop.finish();
+    }
+
+    //! Make others aware of which execution space instance it will synchronize.
+    [[nodiscard]]
+    constexpr auto get_env() const noexcept -> stdexec::__join_env_t<
+        stdexec::prop<ExecutionSpaceImpl::get_exec_t, ExecutionSpaceImpl::ExecutionSpaceRef<Exec>>,
+        env
+    > {
+        return stdexec::__env::__join(
+            stdexec::prop{ExecutionSpaceImpl::get_exec, ExecutionSpaceImpl::ExecutionSpaceRef{state->exec}},
+            env{runloop_state->loop.get_scheduler()});
+    }
+};
+
+struct SyncWait {
+    /**
+     * According to https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#spec-execution.senders.consumers.sync_wait,
+     * it has to return an engaged optional (on the value channel).
+     *
+     * @todo Make the @c noexcept specifier depend on the completion signatures of @p sndr.
+     */
+    template <stdexec::sender Sndr>
+    auto operator()(Sndr&& sndr) const noexcept(false)
+        -> std::optional<stdexec::__sync_wait::__value_tuple_for_t<Sndr>> {
+        State runloop_state;
+
+        auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), stdexec::env{});
+
+        using result_t = std::optional<stdexec::__sync_wait::__value_tuple_for_t<Sndr>>;
+
+        result_t result{};
+
+        auto op_state = stdexec::connect(
+            std::forward<Sndr>(sndr),
+            Receiver{
+                .state = std::move(schd.state),
+                .runloop_state = std::addressof(runloop_state),
+                .result = std::addressof(result)});
+
+        stdexec::start(op_state);
+
+        runloop_state.loop.run();
+
+        if (runloop_state.error)
+            std::rethrow_exception(std::move(runloop_state.error));
+
+        return result;
+    }
+};
+
+} // namespace Kokkos::Execution::Impl::SyncWait
 
 #endif // KOKKOS_EXECUTION_IMPL_SYNC_WAIT_HPP

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -117,7 +117,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
 
     auto op_state = stdexec::connect(
         std::move(schs_A_then_con_B_then_con_h_then), // NOLINT(performance-move-const-arg)
-        Kokkos::Execution::ExecutionSpaceImpl::SyncWaitReceiver<host_execution_space>{
+        Kokkos::Execution::Impl::SyncWait::Receiver<host_execution_space>{
             .state = std::addressof(esc_h.m_state), .runloop_state = nullptr, .result = nullptr});
 
     //! Helper to check that an environment is as expected.
@@ -129,7 +129,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
                     Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
                     Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<Exec>
                 >,
-                stdexec::__env::__fwd<Kokkos::Execution::Impl::env>
+                stdexec::__env::__fwd<Kokkos::Execution::Impl::SyncWait::env>
             >>
         >;
     };
@@ -140,7 +140,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
      */
     using then_rcvr_t =
         Kokkos::Execution::ExecutionSpaceImpl::OpStateReceiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
-            Kokkos::Execution::ExecutionSpaceImpl::SyncWaitReceiver<host_execution_space>,
+            Kokkos::Execution::Impl::SyncWait::Receiver<host_execution_space>,
             Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
                 std::string_view,
                 Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'h'>>,

--- a/tests/execution_space/test_operation_state.cpp
+++ b/tests/execution_space/test_operation_state.cpp
@@ -121,9 +121,7 @@ consteval bool test_delegate_completion_with_event() {
     return true;
 }
 static_assert(test_delegate_completion_with_event<Tests::Utils::SinkReceiver>());
-static_assert(test_delegate_completion_with_event<
-              Kokkos::Execution::ExecutionSpaceImpl::SyncWaitReceiver<TEST_EXECUTION_SPACE>
->());
+static_assert(test_delegate_completion_with_event<Kokkos::Execution::Impl::SyncWait::Receiver<TEST_EXECUTION_SPACE>>());
 
 //! @test Check construction, query for execution space instance, and start.
 TEST_F(OpStateTest, construct_query_and_start) {

--- a/tests/execution_space/test_sync_wait.cpp
+++ b/tests/execution_space/test_sync_wait.cpp
@@ -52,7 +52,7 @@ TEST_F(SyncWaitTest, sync_wait) {
         testing::ElementsAre(MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 }
 
-//! @test Check that @ref Kokkos::Execution::ExecutionSpaceImpl::SyncWait properly rethrows if needed.
+//! @test Check that the @c stdexec::sync_wait of @ref Kokkos::Execution::ExecutionSpaceContext properly rethrows if needed.
 TEST_F(SyncWaitTest, rethrows) {
     const context_t esc{exec};
 

--- a/tests/utils/sink_receiver.hpp
+++ b/tests/utils/sink_receiver.hpp
@@ -9,11 +9,11 @@ namespace Tests::Utils {
 struct SinkReceiver {
     using receiver_concept = stdexec::receiver_t;
 
-    void set_value(auto&&...) noexcept {
+    void set_value(auto&&...) && noexcept {
     }
-    void set_error(auto&&) noexcept {
+    void set_error(auto&&) && noexcept {
     }
-    void set_stopped() noexcept {
+    void set_stopped() && noexcept {
     }
 
     [[nodiscard]]


### PR DESCRIPTION
As discussed with @maartenarnst, the graph customization will store the graph without the operation states instead of the scheduler.

Therefore, we'll be able to completely reuse the execution space sync_wait customization for graph (hopefully).

This PR is a preliminary step that puts everything related to `sync_wait` in the `Kokkos::Execution::Impl::SyncWait` namespace.

It also introduces the `kokkos-execution/impl/state.hpp` file because both scheduler states will be the same as well (and just contain an execution space instance - for now).