### PR TITLE
Impl: `sender_with_tag` is `__sender_for`

### DIFF
--- a/kokkos-execution/impl/sender_concepts.hpp
+++ b/kokkos-execution/impl/sender_concepts.hpp
@@ -18,11 +18,6 @@ concept dispatching_sender = stdexec::sender<Sndr> && requires {
     >;
 };
 
-//! Concept for a sender that has a given tag.
-template <typename Sndr, typename Tag>
-concept sender_with_tag = stdexec::sender<Sndr> && requires { typename stdexec::tag_of_t<Sndr>; }
-                       && std::same_as<stdexec::tag_of_t<Sndr>, Tag>;
-
 } // namespace Kokkos::Execution::Impl
 
 #endif // KOKKOS_EXECUTION_IMPL_SENDER_CONCEPTS_HPP

--- a/tests/execution_space/test_fork_join.cpp
+++ b/tests/execution_space/test_fork_join.cpp
@@ -91,7 +91,7 @@ TEST_F(ForkJoinTest, continues_on) {
             | stdexec::then(
                 Tests::Utils::Functors::LoadCheckAdd<int, on_device>{.prev = 0, .value = 3, .data = data.data()}));
 
-    static_assert(Kokkos::Execution::Impl::sender_with_tag<decltype(sndr), experimental::execution::fork_join_t>);
+    static_assert(stdexec::__sender_for<decltype(sndr), experimental::execution::fork_join_t>);
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -122,7 +122,7 @@ consteval bool test_sndr_decomposition() {
     using pfor_sndr_t = Kokkos::Execution::Impl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>;
 
     //! Is decomposable into the expected algorithm tag, data, and child sender.
-    static_assert(Kokkos::Execution::Impl::sender_with_tag<pfor_sndr_t, Kokkos::Execution::parallel_for_t>);
+    static_assert(stdexec::__sender_for<pfor_sndr_t, Kokkos::Execution::parallel_for_t>);
 
     static_assert(std::same_as<
                   stdexec::__data_of<pfor_sndr_t>,


### PR DESCRIPTION
so we can remove our version :)

https://github.com/NVIDIA/stdexec/blob/47bb920c84be5bdb31e6a1d0f8c47ac6e7d54588/include/stdexec/__detail/__sender_introspection.hpp#L269-L271