### PR TITLE
Impl(event): add stream operator

### DIFF
--- a/kokkos-execution/impl/event.hpp
+++ b/kokkos-execution/impl/event.hpp
@@ -48,6 +48,10 @@ struct RecordEvent {
     uint64_t event_id = 0;
 
     constexpr auto operator<=>(const RecordEvent&) const = default;
+
+    friend std::ostream& operator<<(std::ostream& out, const RecordEvent& event) {
+        return out << "RecordEvent: {dev_id = " << event.dev_id << ", event_id = " << event.event_id << '}';
+    }
 };
 
 template <Kokkos::ExecutionSpace Exec>
@@ -64,6 +68,10 @@ struct WaitEvent {
     uint64_t event_id = 0;
 
     constexpr auto operator<=>(const WaitEvent&) const = default;
+
+    friend std::ostream& operator<<(std::ostream& out, const WaitEvent& event) {
+        return out << "WaitEvent: {event_id = " << event.event_id << '}';
+    }
 };
 
 inline void wait_event(const uint64_t event_id) {

--- a/tests/impl/test_event.cpp
+++ b/tests/impl/test_event.cpp
@@ -89,6 +89,26 @@ consteval bool test_support_events() {
 }
 static_assert(test_support_events<TEST_EXECUTION_SPACE>());
 
+//! @test Check the stream operator of @ref Kokkos::Execution::Impl::RecordEvent.
+TEST(RecordEvent, description) {
+    const Kokkos::Execution::Impl::RecordEvent event{.dev_id = 42, .event_id = 1337};
+
+    std::ostringstream oss;
+    oss << event;
+
+    ASSERT_EQ(oss.str(), "RecordEvent: {dev_id = 42, event_id = 1337}");
+}
+
+//! @test Check the stream operator of @ref Kokkos::Execution::Impl::WaitEvent.
+TEST(WaitEvent, description) {
+    const Kokkos::Execution::Impl::WaitEvent event{.event_id = 1337};
+
+    std::ostringstream oss;
+    oss << event;
+
+    ASSERT_EQ(oss.str(), "WaitEvent: {event_id = 1337}");
+}
+
 #define KOKKOS_EXECUTION_TESTS_IMPL_EVENT(_fixture_, _name_, _statement_)                                              \
     TEST_F(_fixture_, _name_) {                                                                                        \
         if constexpr (EventTest::has_support<TEST_EXECUTION_SPACE>) {                                                  \


### PR DESCRIPTION
Currently, we map to stream operators from kokkos-utils that are not sufficiently constrained.

With a friend function as in:
- #166 