### PR TITLE
domain: broken common_domain due to inheritance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=address"}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=leak"}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=thread -Wno-error=tsan", env: {OMP_NUM_THREADS: 1}}
-          - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "20"}
+          - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "20", extra_type_checking: true}
           - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "23"}
           - kokkos_backends: [HPX]
             compiler:
@@ -109,6 +109,7 @@ jobs:
               version: 22
             runs-on        : "['self-hosted', 'linux', 'docker', 'amd64', 'blackwell120', 'gpu:0']"
             tag_suffix     : -blackwell120
+            extra_type_checking: true
           - kokkos_backends: [OpenMP, HIP]
             compiler:
               family: rocm
@@ -149,6 +150,7 @@ jobs:
       - run: |
           cmake -S . --preset=${{ matrix.compiler.family }}-${{ join(matrix.kokkos_backends, '-') }} \
             -DCMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" \
+            -DKokkosExecution_ENABLE_EXTRA_TYPE_CHECKING=${{ matrix.extra_type_checking && 'ON' || 'OFF' }} \
             -DCMAKE_CXX_STANDARD=${{ matrix.cxxstd || 20 }}
       - run: |
           cmake --build --preset=${{ matrix.compiler.family }}-${{ join(matrix.kokkos_backends, '-') }} -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(kokkos-execution VERSION ${KokkosExecution_VERSION} LANGUAGES CXX)
 option(KokkosExecution_ENABLE_CLANG_TIDY "Enable clang-tidy checks" OFF)
 option(KokkosExecution_ENABLE_DEBUG_LOGGING "Enable debug logging" OFF)
 option(KokkosExecution_ENABLE_DOCS "Enable documentation" OFF)
+option(KokkosExecution_ENABLE_EXTRA_TYPE_CHECKING "Enable extra type checking, but increases compile time" OFF)
 option(KokkosExecution_ENABLE_TESTS "Enable testing" ON)
 
 include(CMakeDependentOption)
@@ -59,6 +60,7 @@ cpmaddpackage(
   "STDEXEC_BUILD_TESTS OFF"
   "STDEXEC_BUILD_EXAMPLES OFF"
   "STDEXEC_INSTALL ON"
+  "STDEXEC_ENABLE_EXTRA_TYPE_CHECKING ${KokkosExecution_ENABLE_EXTRA_TYPE_CHECKING}"
 )
 
 # Compiler warnings.

--- a/kokkos-execution/impl/domain.hpp
+++ b/kokkos-execution/impl/domain.hpp
@@ -3,6 +3,8 @@
 
 #include "kokkos-execution/stdexec.hpp"
 
+#include "Kokkos_TypeInfo.hpp"
+
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)
 #    include "plog/Log.h"
 #endif

--- a/tests/execution_space/CMakeLists.txt
+++ b/tests/execution_space/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_one_test(NAME any_sender)
 add_one_test(NAME bulk)
 add_one_test(NAME continues_on)
+add_one_test(NAME domain)
 add_one_test(NAME ensure_started)
 add_one_test(NAME fork_join)
 add_one_test(NAME inter_op)

--- a/tests/execution_space/test_domain.cpp
+++ b/tests/execution_space/test_domain.cpp
@@ -1,0 +1,32 @@
+#include "gtest/gtest.h"
+
+#include "tests/utils/domain.hpp"
+#include "tests/utils/execution_space_context.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Behavior of @c Kokkos::Execution::ExecutionSpaceImpl::Domain
+ * ------------------------------------------------------------
+ *
+ * This group of tests check the behavior of @ref Kokkos::Execution::ExecutionSpaceImpl::Domain.
+ *
+ * The tests can be found in @ref tests/execution_space/test_domain.cpp.
+ */
+
+namespace Tests::ExecutionSpaceImpl {
+
+class DomainTest : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE> { };
+
+//! @test It properly interacts with other domains inheriting from the @c stdexec::default_domain.
+static_assert(Tests::Utils::check_common_domain_is_default<Kokkos::Execution::ExecutionSpaceImpl::Domain>());
+
+//! @test It will always be non-default-like for @c stdexec::then_t (since it customizes it).
+TEST(DomainTest, not_default_domain_like_then) {
+    static_assert(!Tests::Utils::check_if_default_domain_like_then<
+                  Kokkos::Execution::ExecutionSpaceImpl::Domain,
+                  typename DomainTest::schedule_sender_t
+    >());
+}
+
+} // namespace Tests::ExecutionSpaceImpl

--- a/tests/graph/CMakeLists.txt
+++ b/tests/graph/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_one_test(NAME domain)
 add_one_test(NAME events)
 add_one_test(NAME scheduler)
 add_one_test(NAME sync_wait)

--- a/tests/graph/test_domain.cpp
+++ b/tests/graph/test_domain.cpp
@@ -1,0 +1,32 @@
+#include "gtest/gtest.h"
+
+#include "tests/utils/domain.hpp"
+#include "tests/utils/graph_context.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Behavior of @c Kokkos::Execution::GraphImpl::Domain
+ * ---------------------------------------------------
+ *
+ * This group of tests check the behavior of @ref Kokkos::Execution::GraphImpl::Domain.
+ *
+ * The tests can be found in @ref tests/graph/test_domain.cpp.
+ */
+
+namespace Tests::GraphImpl {
+
+class DomainTest : public Tests::Utils::GraphContextTest<TEST_EXECUTION_SPACE> { };
+
+//! @test It properly interacts with other domains inheriting from the @c stdexec::default_domain.
+static_assert(Tests::Utils::check_common_domain_is_default<Kokkos::Execution::GraphImpl::Domain>());
+
+//! @test It will be default-like for @c stdexec::then_t (since it does not customize it yet).
+TEST(DomainTest, default_domain_like_then) {
+    static_assert(Tests::Utils::check_if_default_domain_like_then<
+                  Kokkos::Execution::GraphImpl::Domain,
+                  typename DomainTest::schedule_sender_t
+    >());
+}
+
+} // namespace Tests::GraphImpl

--- a/tests/utils/domain.hpp
+++ b/tests/utils/domain.hpp
@@ -1,0 +1,41 @@
+#ifndef KOKKOS_EXECUTION_TESTS_UTILS_DOMAIN_HPP
+#define KOKKOS_EXECUTION_TESTS_UTILS_DOMAIN_HPP
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "tests/utils/functors/no_op.hpp"
+
+namespace Tests::Utils {
+
+struct DomainInheritingFromDefault : public stdexec::default_domain { };
+
+//! Check that a domain has the @c stdexec::default_domain as common domain with a few other domains.
+template <typename DomainType>
+consteval bool check_common_domain_is_default() {
+    static_assert(
+        std::same_as<stdexec::__common_domain_t<DomainType, stdexec::default_domain>, stdexec::default_domain>);
+
+    static_assert(
+        std::same_as<stdexec::__common_domain_t<DomainType, DomainInheritingFromDefault>, stdexec::default_domain>);
+
+    return true;
+}
+
+/**
+ * @brief Check if the domain's transform of a @c stdexec::then sender is "default-like".
+ *
+ * Inspired by https://github.com/NVIDIA/stdexec/blob/b06fe4b00d25f226c87d23e7ba1e564c2c878a15/include/stdexec/__detail/__domain.hpp#L98-L102.
+ */
+template <typename DomainType, stdexec::sender ScheduleSenderType>
+consteval bool check_if_default_domain_like_then() {
+    using functor_t = Tests::Utils::Functors::NoOp<false, false, false>;
+    using sndr_t = decltype(stdexec::then(std::declval<ScheduleSenderType>(), std::declval<functor_t>()));
+
+    static_assert(stdexec::__detail::__has_transform_sender<DomainType, stdexec::set_value_t, sndr_t, stdexec::env<>>);
+
+    return stdexec::__default_domain_like<DomainType, stdexec::set_value_t, sndr_t, stdexec::env<>>;
+}
+
+} // namespace Tests::Utils
+
+#endif // KOKKOS_EXECUTION_TESTS_UTILS_DOMAIN_HPP


### PR DESCRIPTION
PRs:
* #155  
* #163 

broken the domain thingy. For now, both domains report that they aren't having the `stdexec::default_domain` in common with the static thread pool scheduler.

We'll start to feel that pain when updating `stdexec` and retrieving:
* https://github.com/NVIDIA/stdexec/pull/2018

I'll provide a fix in a followup.