### PR TITLE
graph: domain must NOT be compatible with the default domain

### DIFF
--- a/kokkos-execution/graph/domain.hpp
+++ b/kokkos-execution/graph/domain.hpp
@@ -8,9 +8,7 @@
 
 namespace Kokkos::Execution::GraphImpl {
 
-struct Domain
-    : public stdexec::default_domain
-    , public Impl::ApplySender<Domain, ApplySenderFor> {
+struct Domain : public Impl::ApplySender<Domain, ApplySenderFor> {
     using Impl::ApplySender<Domain, ApplySenderFor>::apply_sender;
 };
 

--- a/tests/execution_space/test_domain.cpp
+++ b/tests/execution_space/test_domain.cpp
@@ -19,13 +19,45 @@ namespace Tests::ExecutionSpaceImpl {
 class DomainTest : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE> { };
 
 //! @test It properly interacts with other domains inheriting from the @c stdexec::default_domain.
-static_assert(Tests::Utils::check_common_domain_is_default<Kokkos::Execution::ExecutionSpaceImpl::Domain>());
+static_assert(Tests::Utils::check_if_common_domain_is_default<Kokkos::Execution::ExecutionSpaceImpl::Domain>());
 
 //! @test It will always be non-default-like for @c stdexec::then_t (since it customizes it).
 TEST(DomainTest, not_default_domain_like_then) {
-    static_assert(!Tests::Utils::check_if_default_domain_like_then<
+    static_assert(!Tests::Utils::check_if_default_domain_like_for<
                   Kokkos::Execution::ExecutionSpaceImpl::Domain,
+                  stdexec::then_t,
                   typename DomainTest::schedule_sender_t
+    >());
+}
+
+//! @test It will always be non-default-like for @c stdexec::bulk_t (since it customizes it).
+TEST(DomainTest, not_default_domain_like_bulk) {
+    static_assert(!Tests::Utils::check_if_default_domain_like_for<
+                  Kokkos::Execution::ExecutionSpaceImpl::Domain,
+                  stdexec::bulk_t,
+                  typename DomainTest::schedule_sender_t,
+                  stdexec::parallel_policy,
+                  int
+    >());
+}
+
+//! @test It has a transform for a @c stdexec::then_t sender.
+TEST(DomainTest, has_transform_sender_for_then) {
+    static_assert(Tests::Utils::check_if_domain_has_transform_sender_for<
+                  Kokkos::Execution::ExecutionSpaceImpl::Domain,
+                  stdexec::then_t,
+                  typename DomainTest::schedule_sender_t
+    >());
+}
+
+//! @test It has a transform for a @c stdexec::bulk_t sender.
+TEST(DomainTest, has_transform_sender_for_bulk) {
+    static_assert(Tests::Utils::check_if_domain_has_transform_sender_for<
+                  Kokkos::Execution::ExecutionSpaceImpl::Domain,
+                  stdexec::bulk_t,
+                  typename DomainTest::schedule_sender_t,
+                  stdexec::parallel_policy,
+                  int
     >());
 }
 

--- a/tests/graph/test_domain.cpp
+++ b/tests/graph/test_domain.cpp
@@ -18,14 +18,46 @@ namespace Tests::GraphImpl {
 
 class DomainTest : public Tests::Utils::GraphContextTest<TEST_EXECUTION_SPACE> { };
 
-//! @test It properly interacts with other domains inheriting from the @c stdexec::default_domain.
-static_assert(Tests::Utils::check_common_domain_is_default<Kokkos::Execution::GraphImpl::Domain>());
+//! @test It won't interact with other domains inheriting from the @c stdexec::default_domain.
+static_assert(!Tests::Utils::check_if_common_domain_is_default<Kokkos::Execution::GraphImpl::Domain>());
 
 //! @test It will be default-like for @c stdexec::then_t (since it does not customize it yet).
 TEST(DomainTest, default_domain_like_then) {
-    static_assert(Tests::Utils::check_if_default_domain_like_then<
+    static_assert(Tests::Utils::check_if_default_domain_like_for<
                   Kokkos::Execution::GraphImpl::Domain,
+                  stdexec::then_t,
                   typename DomainTest::schedule_sender_t
+    >());
+}
+
+//! @test It will be default-like for @c stdexec::bulk_t (since it does not customize it).
+TEST(DomainTest, default_domain_like_bulk) {
+    static_assert(Tests::Utils::check_if_default_domain_like_for<
+                  Kokkos::Execution::GraphImpl::Domain,
+                  stdexec::bulk_t,
+                  typename DomainTest::schedule_sender_t,
+                  stdexec::parallel_policy,
+                  int
+    >());
+}
+
+//! @test It has no transform for a @c stdexec::then_t sender.
+TEST(DomainTest, has_no_transform_sender_for_then) {
+    static_assert(!Tests::Utils::check_if_domain_has_transform_sender_for<
+                  Kokkos::Execution::GraphImpl::Domain,
+                  stdexec::then_t,
+                  typename DomainTest::schedule_sender_t
+    >());
+}
+
+//! @test It has no transform for a @c stdexec::bulk_t sender.
+TEST(DomainTest, has_no_transform_sender_for_bulk) {
+    static_assert(!Tests::Utils::check_if_domain_has_transform_sender_for<
+                  Kokkos::Execution::GraphImpl::Domain,
+                  stdexec::bulk_t,
+                  typename DomainTest::schedule_sender_t,
+                  stdexec::parallel_policy,
+                  int
     >());
 }
 

--- a/tests/utils/domain.hpp
+++ b/tests/utils/domain.hpp
@@ -9,29 +9,31 @@ namespace Tests::Utils {
 
 struct DomainInheritingFromDefault : public stdexec::default_domain { };
 
-//! Check that a domain has the @c stdexec::default_domain as common domain with a few other domains.
+//! Check if a domain has the @c stdexec::default_domain as common domain with a few other domains.
 template <typename DomainType>
-consteval bool check_common_domain_is_default() {
-    static_assert(
-        std::same_as<stdexec::__common_domain_t<DomainType, stdexec::default_domain>, stdexec::default_domain>);
+consteval bool check_if_common_domain_is_default() {
+    return std::same_as<stdexec::__common_domain_t<DomainType, stdexec::default_domain>, stdexec::default_domain>
+        && std::same_as<stdexec::__common_domain_t<DomainType, DomainInheritingFromDefault>, stdexec::default_domain>;
+}
 
-    static_assert(
-        std::same_as<stdexec::__common_domain_t<DomainType, DomainInheritingFromDefault>, stdexec::default_domain>);
+//! Check if the domain has a transform of a @p Tag sender.
+template <typename DomainType, typename Tag, stdexec::sender ScheduleSenderType, typename... Args>
+consteval bool check_if_domain_has_transform_sender_for() {
+    using functor_t = Tests::Utils::Functors::NoOp<false, false, false>;
+    using sndr_t = std::invoke_result_t<Tag, ScheduleSenderType, Args..., functor_t>;
 
-    return true;
+    return stdexec::__detail::__has_transform_sender<DomainType, stdexec::set_value_t, sndr_t, stdexec::env<>>;
 }
 
 /**
- * @brief Check if the domain's transform of a @c stdexec::then sender is "default-like".
+ * @brief Check if the domain's transform of a @p Tag sender is "default-like".
  *
  * Inspired by https://github.com/NVIDIA/stdexec/blob/b06fe4b00d25f226c87d23e7ba1e564c2c878a15/include/stdexec/__detail/__domain.hpp#L98-L102.
  */
-template <typename DomainType, stdexec::sender ScheduleSenderType>
-consteval bool check_if_default_domain_like_then() {
+template <typename DomainType, typename Tag, stdexec::sender ScheduleSenderType, typename... Args>
+consteval bool check_if_default_domain_like_for() {
     using functor_t = Tests::Utils::Functors::NoOp<false, false, false>;
-    using sndr_t = decltype(stdexec::then(std::declval<ScheduleSenderType>(), std::declval<functor_t>()));
-
-    static_assert(stdexec::__detail::__has_transform_sender<DomainType, stdexec::set_value_t, sndr_t, stdexec::env<>>);
+    using sndr_t = std::invoke_result_t<Tag, ScheduleSenderType, Args..., functor_t>;
 
     return stdexec::__default_domain_like<DomainType, stdexec::set_value_t, sndr_t, stdexec::env<>>;
 }


### PR DESCRIPTION
The algorithm set from the default domain is irremediably irreconciliable with the expectations for the graph scheduler.