### PR TITLE
ExecutionspaceImpl: domain no longer derives from default domain

### DIFF
--- a/kokkos-execution/execution_space/domain.hpp
+++ b/kokkos-execution/execution_space/domain.hpp
@@ -9,8 +9,7 @@
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
 struct Domain
-    : public stdexec::default_domain
-    , public Impl::ApplySender<Domain, ApplySenderFor>
+    : public Impl::ApplySender<Domain, ApplySenderFor>
     , public Impl::TransformSender<Domain, TransformSenderFor> {
     using Impl::ApplySender<Domain, ApplySenderFor>::apply_sender;
     using Impl::TransformSender<Domain, TransformSenderFor>::transform_sender;

--- a/tests/execution_space/test_domain.cpp
+++ b/tests/execution_space/test_domain.cpp
@@ -18,8 +18,8 @@ namespace Tests::ExecutionSpaceImpl {
 
 class DomainTest : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE> { };
 
-//! @test It properly interacts with other domains inheriting from the @c stdexec::default_domain.
-static_assert(Tests::Utils::check_if_common_domain_is_default<Kokkos::Execution::ExecutionSpaceImpl::Domain>());
+//! @test It won't interact with other domains inheriting from the @c stdexec::default_domain.
+static_assert(!Tests::Utils::check_if_common_domain_is_default<Kokkos::Execution::ExecutionSpaceImpl::Domain>());
 
 //! @test It will always be non-default-like for @c stdexec::then_t (since it customizes it).
 TEST(DomainTest, not_default_domain_like_then) {

--- a/tests/execution_space/test_fork_join.cpp
+++ b/tests/execution_space/test_fork_join.cpp
@@ -66,7 +66,8 @@ TEST_F(ForkJoinTest, diamond) {
         | stdexec::then(Tests::Utils::Functors::LoadCheckAdd<int, false>{.prev = 0, .value = 4, .data = data.data()})
         | experimental::execution::fork_join(
             stdexec::continues_on(esc.get_scheduler())
-                | Tests::Utils::check_scheduler_type<stdexec::set_value_t, scheduler_t>() | THEN_INCREMENT_ATOMIC(data),
+                | Tests::Utils::check_scheduler_type<stdexec::set_value_t, scheduler_t>() | THEN_INCREMENT_ATOMIC(data)
+                | stdexec::continues_on(pool.get_scheduler()),
             stdexec::continues_on(pool.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
         | stdexec::continues_on(esc.get_scheduler())
         | stdexec::then(
@@ -78,24 +79,13 @@ TEST_F(ForkJoinTest, diamond) {
 
     KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP(sndr)
 
-    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
-
-    ASSERT_THAT(recorded_events, [&]() {
-        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_RECORD_EVENT(exec),
-                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")));
-        } else {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")));
-        }
-    }());
+    ASSERT_THAT(
+        Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr)),
+        testing::ElementsAre(
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")),
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from"))));
 
     ASSERT_EQ(data(), 14);
 }

--- a/tests/execution_space/test_split.cpp
+++ b/tests/execution_space/test_split.cpp
@@ -69,7 +69,8 @@ TEST_F(SplitTest, within) {
 
     auto branch_a = fork | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
                   | THEN_INCREMENT_ATOMIC(data);
-    auto branch_b = fork | stdexec::continues_on(pool.get_scheduler()) | THEN_INCREMENT_ATOMIC(data);
+    auto branch_b = fork | stdexec::continues_on(pool.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
+                  | stdexec::continues_on(esc.get_scheduler());
     auto branch_c = std::move(fork) | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
                   | THEN_INCREMENT_ATOMIC(data);
 
@@ -83,10 +84,11 @@ TEST_F(SplitTest, within) {
 
     static_assert(std::same_as<
                   stdexec::__completion_domain_of_t<stdexec::set_value_t, decltype(w_a), stdexec::env<>>,
-                  stdexec::default_domain
+                  Kokkos::Execution::ExecutionSpaceImpl::Domain
     >);
 
-    stdexec::sender auto sndr = std::move(w_a) | stdexec::then([&data]() { EXPECT_EQ(data(), 5); });
+    stdexec::sender auto sndr = std::move(w_a) | stdexec::continues_on(stdexec::inline_scheduler{})
+                              | stdexec::then([&data]() { EXPECT_EQ(data(), 5); });
 
     static_assert(stdexec::dependent_sender<decltype(sndr)>);
 

--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -208,12 +208,10 @@ TEST_F(WhenAllTest, single_branch_followed_by_other_and_finish_on_self) {
  *       on another context, followed by work on the same @ref Kokkos::Execution::ExecutionSpaceContext.
  *
  * @verbatim
- * schedule(esc) | then_atomic -- \
- *                                 when_all --> continues_on(esc) | then
- * schedule(stc) | then_atomic -- /
+ * schedule(esc) | then_atomic ------------------------ \
+ *                                                       when_all --> continues_on(esc) | then
+ * schedule(stc) | then_atomic --> continues_on(esc) -- /
  * @endverbatim
- *
- * @todo Too many synchronizations.
  */
 TEST_F(WhenAllTest, two_mixed_branches_followed_by_self) {
     const view_s_t data(Kokkos::view_alloc("data - shared space"));
@@ -223,12 +221,13 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_self) {
 
     auto w_a = stdexec::when_all(
         stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
-        stdexec::schedule(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data));
+        stdexec::schedule(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
+            | stdexec::continues_on(esc.get_scheduler()));
 
     static_assert(
         std::same_as<
             decltype(stdexec::get_completion_domain<stdexec::set_value_t>(stdexec::get_env(w_a), stdexec::env<>{})),
-            stdexec::default_domain
+            Kokkos::Execution::ExecutionSpaceImpl::Domain
         >);
 
     auto sndr = std::move(w_a) | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
@@ -237,24 +236,12 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_self) {
 
     KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP(sndr)
 
-    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
-
-    ASSERT_THAT(recorded_events, [&]() {
-        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_RECORD_EVENT(exec),
-                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-        } else {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-        }
-    }());
+    ASSERT_THAT(
+        Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr)),
+        testing::ElementsAre(
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 
     ASSERT_EQ(data(), 3);
 }
@@ -386,9 +373,9 @@ TEST_F(WhenAllTest, two_branches_host_device_followed_by_device) {
  *       on the same @ref Kokkos::Execution::ExecutionSpaceContext.
  *
  * @verbatim
- * schedule(esc) | then_atomic -- \
- *                                 when_all --> continues_on(stc) | then --> continues_on(esc) | then
- * schedule(stc) | then_atomic -- /
+ * schedule(esc) | then_atomic --> continues_on(stc) -- \
+ *                                                       when_all --> continues_on(stc) | then --> continues_on(esc) | then
+ * schedule(stc) | then_atomic ------------------------ /
  * @endverbatim
  */
 TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
@@ -398,7 +385,8 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
     experimental::execution::single_thread_context stc{};
 
     auto sndr = stdexec::when_all(
-                    stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
+                    stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
+                        | stdexec::continues_on(stc.get_scheduler()),
                     stdexec::schedule(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
               | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT(data)
               | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
@@ -407,24 +395,13 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
 
     KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP(sndr)
 
-    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
-
-    ASSERT_THAT(recorded_events, [&]() {
-        if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_RECORD_EVENT(exec),
-                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-        } else {
-            return testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
-                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
-        }
-    }());
+    ASSERT_THAT(
+        Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr)),
+        testing::ElementsAre(
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")),
+            MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
 
     ASSERT_EQ(data(), 4);
 }
@@ -438,12 +415,10 @@ TEST_F(WhenAllTest, two_mixed_branches_followed_by_other_and_finish_on_self) {
  *       because its preceding @c stdexec::when_all has at least one branch on @ref Kokkos::Execution::ExecutionSpaceContext.
  *
  * @verbatim
- * schedule(esc) | then_atomic -------------------------------------------------- \
- *                                                                                 when_all --> continues_on(esc) | then
- * schedule(esc) | then_atomic -- when_all --> continues_on(stc) | then_atomic -- /
+ * schedule(esc) | then_atomic ------------------------------------------------------------------------ \
+ *                                                                                                       when_all --> continues_on(esc) | then
+ * schedule(esc) | then_atomic -- when_all --> continues_on(stc) | then_atomic --> continues_on(stc) -- /
  * @endverbatim
- *
- * @todo Too many synchronizations.
  */
 TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
     const view_s_t data(Kokkos::view_alloc("data - shared space"));
@@ -456,7 +431,8 @@ TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
             stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
             stdexec::when_all(stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
                 | Tests::Utils::check_rcvr_env_not_queryable_with<Kokkos::Execution::ExecutionSpaceImpl::get_exec_t>()
-                | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
+                | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
+                | stdexec::continues_on(esc.get_scheduler()))
         | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
@@ -469,17 +445,14 @@ TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
         if constexpr (Kokkos::Execution::Impl::support_events<TEST_EXECUTION_SPACE>) {
             return testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_RECORD_EVENT(exec),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_RECORD_EVENT(exec),
-                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
-                MATCHER_FOR_WAIT_EVENT(recorded_events.at(3)),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(2)),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
         } else {
             return testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),


### PR DESCRIPTION
Follow up for:
- https://github.com/NVIDIA/stdexec/pull/2018

Similar to:
- https://github.com/uliegecsm/kokkos-execution/pull/175

See:
- https://github.com/NVIDIA/stdexec/issues/1937#issuecomment-4240669000