### PR TITLE
tests(utils): check rcvr env type

### DIFF
--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/utils/callback_matchers.hpp"
 #include "tests/utils/check_continues_on.hpp"
+#include "tests/utils/check_rcvr_env.hpp"
 #include "tests/utils/execution_space_context.hpp"
 #include "tests/utils/functors/increment.hpp"
 #include "tests/utils/functors/labeled.hpp"
@@ -372,9 +373,26 @@ TEST_F(ContinuesOnTest, transition_to_another_execution_space_instance_and_back_
     Tests::Utils::show_exec_space_id(exec, "exec");
     Tests::Utils::show_exec_space_id(exec_h, "exec_h");
 
+    using level_C_env_t = Kokkos::Execution::Impl::SyncWait::env;
+    using level_B_env_t = stdexec::__env::__fwd<stdexec::env<
+        stdexec::prop<
+            Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
+            Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<TEST_EXECUTION_SPACE>
+        >,
+        stdexec::__env::__fwd<level_C_env_t>
+    >>;
+    using level_A_env_t = stdexec::__env::__fwd<stdexec::env<
+        stdexec::prop<
+            Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
+            Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<host_execution_space>
+        >,
+        level_B_env_t
+    >>;
     auto chain = stdexec::just() | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data)
-               | stdexec::continues_on(esc_h.get_scheduler()) | THEN_INCREMENT(data)
-               | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
+               | Tests::Utils::check_rcvr_env<level_A_env_t>() | stdexec::continues_on(esc_h.get_scheduler())
+               | THEN_INCREMENT(data) | Tests::Utils::check_rcvr_env<level_B_env_t>()
+               | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data)
+               | Tests::Utils::check_rcvr_env<level_C_env_t>();
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_one_test(NAME check_scheduler_type)
+add_one_test(NAME check_rcvr_env)
 add_one_test(NAME check_rcvr_env_queryable_with)

--- a/tests/utils/check_rcvr_env.hpp
+++ b/tests/utils/check_rcvr_env.hpp
@@ -1,0 +1,54 @@
+#ifndef KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_HPP
+#define KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_HPP
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "kokkos-execution/impl/attributes.hpp"
+#include "kokkos-execution/impl/completion_signatures.hpp"
+
+namespace Tests::Utils {
+
+template <typename ExpectedEnv, typename Sndr>
+struct CheckRcvrEnvSender {
+    using sender_concept = stdexec::sender_tag;
+
+    Sndr sndr;
+
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvSender)
+
+    template <stdexec::receiver Rcvr>
+    constexpr auto connect(Rcvr rcvr) && noexcept(stdexec::__nothrow_connectable<Sndr&&, Rcvr&&>) {
+        static_assert(std::same_as<ExpectedEnv, stdexec::env_of_t<Rcvr>>);
+        return stdexec::connect(std::forward<Sndr>(sndr), std::move(rcvr));
+    }
+
+    template <stdexec::receiver Rcvr>
+    constexpr auto connect(Rcvr rcvr) const & noexcept(stdexec::__nothrow_connectable<Sndr const &, Rcvr&&>) {
+        static_assert(std::same_as<ExpectedEnv, stdexec::env_of_t<Rcvr>>);
+        return stdexec::connect(sndr, std::move(rcvr));
+    }
+
+    KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
+};
+
+//! Check that the receiver environment is of type @p ExpectedEnv.
+template <typename ExpectedEnv>
+struct check_rcvr_env_t {
+    [[nodiscard]]
+    constexpr auto operator()() const noexcept {
+        return stdexec::__closure(*this);
+    }
+
+    template <stdexec::sender Sndr>
+    [[nodiscard]]
+    constexpr auto operator()(Sndr&& sndr) const {
+        return CheckRcvrEnvSender<ExpectedEnv, Sndr>{std::forward<Sndr>(sndr)};
+    }
+};
+
+template <typename ExpectedEnv>
+inline constexpr check_rcvr_env_t<ExpectedEnv> check_rcvr_env{};
+
+} // namespace Tests::Utils
+
+#endif // KOKKOS_EXECUTION_TESTS_UTILS_CHECK_RCVR_ENV_HPP

--- a/tests/utils/test_check_rcvr_env.cpp
+++ b/tests/utils/test_check_rcvr_env.cpp
@@ -1,0 +1,49 @@
+#include "gtest/gtest.h"
+
+#include "tests/utils/check_rcvr_env.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Tests for @c Tests::Utils::check_rcvr_env
+ * -----------------------------------------
+ *
+ * This group of tests check the behavior of @ref Tests::Utils::check_rcvr_env.
+ *
+ * The tests can be found in @ref tests/utils/test_check_rcvr_env.cpp.
+ */
+
+namespace Tests {
+
+constexpr struct PropA : public ::stdexec::__query<PropA> {
+} prop_a{};
+
+constexpr struct PropB : public ::stdexec::__query<PropB> {
+} prop_b{};
+
+consteval auto get_sndr() {
+    using expected_env_t = stdexec::env<
+        const stdexec::prop<Tests::PropA, double>&,
+        stdexec::__env::__fwd<stdexec::env<
+            const stdexec::__env::__fwd<stdexec::prop<Tests::PropB, double>>&,
+            stdexec::__env::__fwd<stdexec::__sync_wait::__env>
+        >>
+    >;
+
+    return stdexec::just() | Tests::Utils::check_rcvr_env<expected_env_t>()
+         | stdexec::write_env(stdexec::prop{prop_a, 42.}) | stdexec::then([]() { })
+         | stdexec::write_env(stdexec::__fwd_env(stdexec::prop{prop_b, 666.}));
+}
+
+//! @test Check @ref Tests::Utils::check_rcvr_env with an rvalue sender.
+TEST(check_rcvr_env, rvalue) {
+    stdexec::sync_wait(get_sndr());
+}
+
+//! @test Check @ref Tests::Utils::check_rcvr_env with an lvalue sender.
+TEST(check_rcvr_env, lvalue) {
+    auto sndr = get_sndr();
+    stdexec::sync_wait(sndr);
+}
+
+} // namespace Tests

--- a/tests/utils/test_check_rcvr_env_queryable_with.cpp
+++ b/tests/utils/test_check_rcvr_env_queryable_with.cpp
@@ -1,7 +1,5 @@
 #include "gtest/gtest.h"
 
-#include "kokkos-execution/stdexec.hpp"
-
 #include "tests/utils/check_rcvr_env_queryable_with.hpp"
 
 /**


### PR DESCRIPTION
This PR adds a helper to check the receiver environment.