### PR TITLE
exec: avoid that our senders be transformed recursively

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -11,3 +11,9 @@
     author = {Niebler, Eric},
     howpublished = {\url{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html}},
 }
+
+@misc{P3826R3,
+    title = {Fix Sender Algorithm Customization},
+    author = {Niebler, Eric},
+    howpublished = {\url{https://isocpp.org/files/papers/P3826R3.html}},
+}

--- a/kokkos-execution/execution_space/bulk.hpp
+++ b/kokkos-execution/execution_space/bulk.hpp
@@ -15,6 +15,7 @@ template <>
 struct TransformSenderFor<stdexec::bulk_t> {
     template <typename Env, typename Data, typename Sndr>
     using trnsfrmd_sndr_t = ParallelForSender<
+        stdexec::bulk_t,
         Sndr,
         std::string_view,
         typename Kokkos::Execution::Impl::bulk_traits<Data>::functor_t,
@@ -30,7 +31,6 @@ struct TransformSenderFor<stdexec::bulk_t> {
         Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
                  trnsfrmd_sndr_t<Env, Data, Sndr>,
-                 parallel_for_t,
                  typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t&&,
                  Sndr&&
         >) {
@@ -40,7 +40,6 @@ struct TransformSenderFor<stdexec::bulk_t> {
             auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
             return trnsfrmd_sndr_t<Env, Data, Sndr>{
-                parallel_for_t{},
                 {{Impl::dispatch_label<Impl::exec_of_t<Sndr, Env>, ": bulk">(),
                   stdexec::__forward_like<Data>(functor),
                   Kokkos::RangePolicy<Impl::exec_of_t<Sndr, Env>>(schd.state->exec, 0, shape)}},

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -33,14 +33,13 @@ struct ParallelForClosure {
     }
 };
 
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
+template <typename Tag, stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
 struct ParallelForSender {
     using sender_concept = stdexec::sender_tag;
 
     using closure_t = ParallelForClosure<Label, Functor, ExecPolicy>;
     using execution_space = typename closure_t::execution_space;
 
-    parallel_for_t tag;
     closure_t clsr;
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
@@ -60,6 +59,7 @@ template <>
 struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
     template <typename Env, typename Data, typename Sndr>
     using trnsfrmd_sndr_t = ParallelForSender<
+        parallel_for_t,
         Sndr,
         typename std::remove_cvref_t<Data>::label_t,
         typename std::remove_cvref_t<Data>::functor_t,
@@ -71,7 +71,6 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
     auto operator()(const Env& env, Kokkos::Execution::parallel_for_t, Data&& data, Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
                  trnsfrmd_sndr_t<Env, Data, Sndr>,
-                 parallel_for_t,
                  typename trnsfrmd_sndr_t<Env, Data, Sndr>::closure_t&&,
                  Sndr&&
         >) {
@@ -90,7 +89,6 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
                 "type.");
 
             return trnsfrmd_sndr_t<Env, Data, Sndr>{
-                parallel_for_t{},
                 {{std::move(label),
                   std::move(functor),
                   typename std::remove_cvref_t<Data>::policy_t(
@@ -103,17 +101,5 @@ struct TransformSenderFor<Kokkos::Execution::parallel_for_t> {
 };
 
 } // namespace Kokkos::Execution::ExecutionSpaceImpl
-
-#if !STDEXEC_HAS_BUILTIN(__builtin_structured_binding_size)
-namespace stdexec {
-
-//! See also https://cor3ntin.github.io/posts/clang21/#__builtin_structured_binding_size.
-template <stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
-inline constexpr auto __structured_binding_size_v< // NOLINT(bugprone-reserved-identifier)
-    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Sndr, Label, Functor, ExecPolicy>
-> = 3;
-
-} // namespace stdexec
-#endif
 
 #endif // KOKKOS_EXECUTION_EXECUTION_SPACE_PARALLEL_FOR_HPP

--- a/kokkos-execution/execution_space/then.hpp
+++ b/kokkos-execution/execution_space/then.hpp
@@ -28,14 +28,14 @@ struct TransformSenderFor<stdexec::then_t> {
     using policy_t = Kokkos::RangePolicy<Impl::exec_of_t<Sndr, Env>, Kokkos::LaunchBounds<1>>;
 
     template <typename Env, typename Functor, typename Sndr>
-    using trnsfrmd_sndr_t = ParallelForSender<Sndr, std::string_view, ThenWrapper<Functor>, policy_t<Sndr, Env>>;
+    using trnsfrmd_sndr_t =
+        ParallelForSender<stdexec::then_t, Sndr, std::string_view, ThenWrapper<Functor>, policy_t<Sndr, Env>>;
 
     template <typename Env, typename Functor, typename Sndr>
     requires stdexec::__sends<stdexec::set_value_t, Sndr, Env>
     auto operator()(const Env& env, stdexec::then_t, Functor&& functor, Sndr&& sndr) const
         noexcept(std::is_nothrow_constructible_v<
                  trnsfrmd_sndr_t<Env, Functor, Sndr>,
-                 parallel_for_t,
                  typename trnsfrmd_sndr_t<Env, Functor, Sndr>::closure_t&&,
                  Sndr&&
         >) {
@@ -43,7 +43,6 @@ struct TransformSenderFor<stdexec::then_t> {
             auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env);
 
             return trnsfrmd_sndr_t<Env, Functor, Sndr>{
-                parallel_for_t{},
                 {{Impl::dispatch_label<Impl::exec_of_t<Sndr, Env>, ": then">(),
                   ThenWrapper<Functor>{std::forward<Functor>(functor)},
                   policy_t<Sndr, Env>(schd.state->exec, 0, 1)}},

--- a/tests/execution_space/test_bulk.cpp
+++ b/tests/execution_space/test_bulk.cpp
@@ -56,6 +56,7 @@ consteval bool test_sndr_traits() {
     static_assert(std::same_as<
                   bulk_sndr_t,
                   Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<
+                      stdexec::bulk_t,
                       schd_sndr_t,
                       std::string_view,
                       functor_t,
@@ -67,8 +68,8 @@ consteval bool test_sndr_traits() {
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::execution_space_completing_sender<bulk_sndr_t>);
     static_assert(std::same_as<Kokkos::Execution::Impl::exec_of_t<bulk_sndr_t>, TEST_EXECUTION_SPACE>);
 
-    //! Models the dispatching sender concept.
-    static_assert(Kokkos::Execution::Impl::dispatching_sender<bulk_sndr_t>);
+    //! Does not model the dispatching sender concept.
+    static_assert(!Kokkos::Execution::Impl::dispatching_sender<bulk_sndr_t>);
 
     return true;
 }

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -50,7 +50,7 @@ class ParallelForTest
  * @test Check traits of sender returned by @ref Kokkos::Execution::parallel_for either uncustomized
  *       or customized for @ref Kokkos::Execution::ExecutionSpaceContext.
  */
-template <template <typename, typename, typename, typename> class SndrAdptr>
+template <template <typename...> class SndrAdptr, bool IsDispatchingSender, typename... Args>
 consteval bool test_sndr_traits() {
     //! Schedule sender.
     using schd_sndr_t = typename ParallelForTest::schedule_sender_t;
@@ -59,14 +59,14 @@ consteval bool test_sndr_traits() {
     using label_t = std::string;
     using functor_t = Tests::Utils::Functors::SumIndices<typename ParallelForTest::view_s_t>;
     using policy_t = Kokkos::RangePolicy<TEST_EXECUTION_SPACE>;
-    using pfor_sndr_t = SndrAdptr<schd_sndr_t, label_t, functor_t, policy_t>;
+    using pfor_sndr_t = SndrAdptr<Args..., schd_sndr_t, label_t, functor_t, policy_t>;
 
     //! Models the execution space completing sender concept.
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::execution_space_completing_sender<pfor_sndr_t>);
     static_assert(std::same_as<Kokkos::Execution::Impl::exec_of_t<pfor_sndr_t>, TEST_EXECUTION_SPACE>);
 
     //! Models the dispatching sender concept.
-    static_assert(Kokkos::Execution::Impl::dispatching_sender<pfor_sndr_t>);
+    static_assert(Kokkos::Execution::Impl::dispatching_sender<pfor_sndr_t> == IsDispatchingSender);
 
     //! Has the expected completion signatures.
     using completion_signatures_t = stdexec::__completion_signatures_of_t<pfor_sndr_t, stdexec::env<>>;
@@ -93,7 +93,13 @@ consteval bool test_sndr_traits() {
 
     static_assert(std::same_as<
                   stdexec::transform_sender_result_t<pfor_sndr_t, stdexec::env_of_t<Tests::Utils::SinkReceiver>>,
-                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<schd_sndr_t, label_t, functor_t, policy_t>
+                  Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<
+                      Kokkos::Execution::parallel_for_t,
+                      schd_sndr_t,
+                      label_t,
+                      functor_t,
+                      policy_t
+                  >
     >);
 
 //! @bug https://github.com/kokkos/kokkos/blob/393d4165a6c3687e78abe5e1665853f1eabc386d/core/src/Kokkos_View.hpp#L697
@@ -117,8 +123,12 @@ consteval bool test_sndr_traits() {
 
     return true;
 }
-static_assert(test_sndr_traits<Kokkos::Execution::Impl::ParallelForSender>());
-static_assert(test_sndr_traits<Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender>());
+static_assert(test_sndr_traits<Kokkos::Execution::Impl::ParallelForSender, true>());
+static_assert(test_sndr_traits<
+              Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender,
+              false,
+              Kokkos::Execution::parallel_for_t
+>());
 
 //! @test Check decomposition of @ref Kokkos::Execution::Impl::ParallelForSender into the algorithm tag, data, and child sender.
 consteval bool test_sndr_decomposition() {

--- a/tests/execution_space/test_then.cpp
+++ b/tests/execution_space/test_then.cpp
@@ -60,8 +60,8 @@ consteval bool test_sndr_traits() {
     static_assert(Kokkos::Execution::ExecutionSpaceImpl::execution_space_completing_sender<then_sndr_t>);
     static_assert(std::same_as<Kokkos::Execution::Impl::exec_of_t<then_sndr_t>, TEST_EXECUTION_SPACE>);
 
-    //! Models the dispatching sender concept.
-    static_assert(Kokkos::Execution::Impl::dispatching_sender<then_sndr_t>);
+    //! Does not model the dispatching sender concept.
+    static_assert(!Kokkos::Execution::Impl::dispatching_sender<then_sndr_t>);
 
     //! The policy used in the parallel for created by the @c then sender has the expected launch bounds.
     using policy_t = typename then_sndr_t::closure_t::policy_t;


### PR DESCRIPTION
This PR ensures that the tag makes its way to the `Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender` (`then`, `bulk` or `parallel_for_t`).

Doing so, since `Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender` is a tuple-like type and since the tag is known, the double-transformation machinery of *P3826R3* kicks in, and fails the compilation.

The fix is to avoid storing the `tag` as a member in `Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender`.

### Old fix

The fix is to specialize `stdexec::__structured_binding_size_v` to ensure that the `stdexec::default_domain` transformations are ill-formed and not picked up.

```c++
namespace stdexec {

/**
 * @brief Avoid that transformations of the @c stdexec::default_domain be well-formed for @ref Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender.
 *
 * According to @cite P3826R3, @c connect will proceed along these lines:
 *  1. Determine the starting and completing domains of the sender.
 *  2. Apply the completing domain transform (if well-formed).
 *  3. Apply the starting domain transform (if well-formed).
 *  4. Connects the twice-transformed sender to the receiver.
 *
 * If @ref Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender::tag is known to the default domain, and since it is
 * tuple-like, the @c stdexec::default_domain transformation would be well-formed, but the compilation would typically
 * fail later on when the transformation is applied. Indeed, https://github.com/NVIDIA/stdexec/blob/fcbaee9b98063dd3549ff71fb8211812f290173f/include/stdexec/__detail/__bulk.hpp#L379-L388
 * assumes that the sender decomposes into a tag, some data and a child sender, with the data having a @c __pol_ member.
 *
 * Specializing @c stdexec::__structured_binding_size_v is a way to avoid that @c stdexec::default_domain transformations
 * kick in, while keeping the aggregate-like layout.
 */
template <typename Tag, stdexec::sender Sndr, typename Label, typename Functor, Kokkos::ExecutionPolicy ExecPolicy>
inline constexpr auto __structured_binding_size_v< // NOLINT(bugprone-reserved-identifier)
    Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<Tag, Sndr, Label, Functor, ExecPolicy>
> = -1;

} // namespace stdexec

//! @test Ensure that @c stdexec::__structured_binding_size_v is specialized for @ref Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender.
template <typename Tag>
consteval bool test_structured_binding_size() {
    using sndr_t = Kokkos::Execution::ExecutionSpaceImpl::ParallelForSender<
        Tag,
        typename ParallelForTest::schedule_sender_t,
        std::string,
        Tests::Utils::Functors::NoOp<false, false, false>,
        Kokkos::RangePolicy<TEST_EXECUTION_SPACE>
    >;

#if STDEXEC_HAS_BUILTIN(__builtin_structured_binding_size)
    static_assert(__builtin_structured_binding_size(sndr_t) == 3);
#endif

    static_assert(stdexec::__structured_binding_size_v<sndr_t> == -1);

    return true;
}
static_assert(test_structured_binding_size<stdexec::bulk_t>());
static_assert(test_structured_binding_size<stdexec::then_t>());
static_assert(test_structured_binding_size<Kokkos::Execution::parallel_for_t>());
```