### PR TITLE
graph(events): add node does not need device handle argument

### DIFF
--- a/kokkos-execution/graph/events.hpp
+++ b/kokkos-execution/graph/events.hpp
@@ -106,18 +106,19 @@ auto create_graph(const Kokkos::Impl::DeviceHandle<Exec>& device_handle, Args&&.
  *
  * @todo There is no way to tell if the predecessor is a root node.
  */
-template <bool IsRoot, Kokkos::ExecutionSpace Exec, typename PredecessorRef, typename NodeRef>
-void graph_add_node_event(
-    const Kokkos::Impl::DeviceHandle<Exec>& handle,
-    const PredecessorRef& predecessor,
-    const NodeRef& node) {
+template <bool IsRoot, typename PredecessorRef, typename NodeRef>
+requires(
+    Kokkos::Impl::is_specialization_of_v<PredecessorRef, Kokkos::Experimental::GraphNodeRef>
+    && Kokkos::Impl::is_specialization_of_v<NodeRef, Kokkos::Experimental::GraphNodeRef>)
+void graph_add_node_event(const PredecessorRef& predecessor, const NodeRef& node) {
 #if defined(KOKKOS_EXECUTION_ENABLE_EVENT_DISPATCH)
+    auto* const node_ptr = get_node_ptr(node);
     Kokkos::utils::callbacks::dispatch(
         GraphAddNodeEvent{
             .graph = get_graph_impl_ptr(predecessor),
             .predecessor = IsRoot ? nullptr : get_node_ptr(predecessor),
-            .node = get_node_ptr(node),
-            .dev_id = Kokkos::Tools::Experimental::device_id(handle.m_exec)});
+            .node = node_ptr,
+            .dev_id = Kokkos::Tools::Experimental::device_id(node_ptr->get_device_handle().m_exec)});
 #endif
 }
 

--- a/tests/graph/test_events.cpp
+++ b/tests/graph/test_events.cpp
@@ -53,9 +53,7 @@ consteval bool test_noexcept() {
         !noexcept(Kokkos::Execution::GraphImpl::create_graph(std::declval<const EventsTest::device_handle_t&>())));
 
     static_assert(!noexcept(Kokkos::Execution::GraphImpl::graph_add_node_event<true>(
-        std::declval<const EventsTest::device_handle_t&>(),
-        std::declval<const EventsTest::graph_t::root_t&>(),
-        std::declval<const EventsTest::graph_t::root_t&>())));
+        std::declval<const EventsTest::graph_t::root_t&>(), std::declval<const EventsTest::graph_t::root_t&>())));
 
     static_assert(
         !noexcept(Kokkos::Execution::GraphImpl::graph_instantiate_event(std::declval<const EventsTest::graph_t&>())));
@@ -97,10 +95,10 @@ TEST_F(EventsTest, create_and_add_nodes) {
         const auto root = graph.root_node();
 
         const auto node_A = root.then(Kokkos::Experimental::node_props(device_handle), KOKKOS_LAMBDA(){});
-        Kokkos::Execution::GraphImpl::graph_add_node_event<true>(device_handle, root, node_A);
+        Kokkos::Execution::GraphImpl::graph_add_node_event<true>(root, node_A);
 
         const auto node_B = node_A.then(Kokkos::Experimental::node_props(device_handle), KOKKOS_LAMBDA(){});
-        Kokkos::Execution::GraphImpl::graph_add_node_event<false>(device_handle, node_A, node_B);
+        Kokkos::Execution::GraphImpl::graph_add_node_event<false>(node_A, node_B);
     });
     ASSERT_THAT(
         recorded_events,


### PR DESCRIPTION
The node itself can be queried for its device handle.