### PR TITLE
events: exec wait for event

### DIFF
--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -110,7 +110,7 @@ struct WaitEventReceiver {
 
     void set_value() && noexcept {
         try {
-            opstate->event->wait();
+            Impl::wait(opstate->event.__get());
             opstate->event.__destroy();
             opstate->storage.__destroy();
             stdexec::set_value(std::move(opstate->rcvr));
@@ -154,7 +154,8 @@ struct MayDelegateCompletionWithEvent<Rcvr, Exec, true> {
     template <typename OpState>
     void delegate(OpState* const opstate) noexcept {
         if (RequiresSynchronization<Rcvr, OpState>{}(*opstate)) {
-            event.__construct(opstate->query(get_exec).get());
+            event.__construct();
+            Impl::record(event.__get(), opstate->query(get_exec).get());
             storage.__construct_from(
                 stdexec::connect,
                 stdexec::schedule(stdexec::get_delegation_scheduler(stdexec::get_env(this->rcvr))),

--- a/kokkos-execution/impl/Cuda/event.hpp
+++ b/kokkos-execution/impl/Cuda/event.hpp
@@ -20,11 +20,6 @@ struct Event<Kokkos::Cuda> {
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
-
-    explicit Event(const Kokkos::Cuda& exec) {
-        record(exec);
-    }
-
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&&) noexcept = delete;
@@ -40,16 +35,20 @@ struct Event<Kokkos::Cuda> {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventCreateWithFlags(&m_event, cudaEventDisableTiming));
         }
         KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventRecord(m_event, exec.cuda_stream()));
-        record_event(exec, m_event_id);
     }
 
     void wait() const {
-        wait_event(m_event_id);
         if (cudaEventQuery(m_event) != cudaSuccess) {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(m_event));
         }
     }
 };
+
+template <>
+void impl_wait(const Kokkos::Cuda& exec, const Event<Kokkos::Cuda>& event) {
+    KOKKOS_EXPECTS(bool(event.m_event));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamWaitEvent(exec.cuda_stream(), event.m_event));
+}
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/HIP/event.hpp
+++ b/kokkos-execution/impl/HIP/event.hpp
@@ -20,11 +20,6 @@ struct Event<Kokkos::HIP> {
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
-
-    explicit Event(const Kokkos::HIP& exec) {
-        record(exec);
-    }
-
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&&) noexcept = delete;
@@ -40,16 +35,20 @@ struct Event<Kokkos::HIP> {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventCreateWithFlags(&m_event, hipEventDisableTiming));
         }
         KOKKOS_IMPL_HIP_SAFE_CALL(hipEventRecord(m_event, exec.hip_stream()));
-        record_event(exec, m_event_id);
     }
 
     void wait() const {
-        wait_event(m_event_id);
         if (hipEventQuery(m_event) != hipSuccess) {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(m_event));
         }
     }
 };
+
+template <>
+void impl_wait(const Kokkos::HIP& exec, const Event<Kokkos::HIP>& event) {
+    KOKKOS_EXPECTS(bool(event.m_event));
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamWaitEvent(exec.hip_stream(), event.m_event));
+}
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/HPX/event.hpp
+++ b/kokkos-execution/impl/HPX/event.hpp
@@ -24,11 +24,6 @@ struct Event<Kokkos::Experimental::HPX> {
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
-
-    explicit Event(const Kokkos::Experimental::HPX& exec) {
-        record(exec);
-    }
-
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&&) noexcept = delete;
@@ -37,7 +32,6 @@ struct Event<Kokkos::Experimental::HPX> {
 
     void record(const Kokkos::Experimental::HPX& exec) {
         m_exec = exec;
-        record_event(exec, m_event_id);
     }
 
     /**
@@ -56,7 +50,6 @@ struct Event<Kokkos::Experimental::HPX> {
      * it's the most reasonable way forward for now.
      */
     void wait() const {
-        wait_event(m_event_id);
         if (m_exec.has_value()) {
             auto& instance_data = m_exec->impl_get_instance_data();
 

--- a/kokkos-execution/impl/SYCL/event.hpp
+++ b/kokkos-execution/impl/SYCL/event.hpp
@@ -20,11 +20,6 @@ struct Event<Kokkos::SYCL> {
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
-
-    explicit Event(const Kokkos::SYCL& exec) {
-        record(exec);
-    }
-
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&& other) noexcept = delete;
@@ -36,17 +31,21 @@ struct Event<Kokkos::SYCL> {
      */
     void record(const Kokkos::SYCL& exec) {
         m_event = exec.sycl_queue().ext_oneapi_submit_barrier();
-        record_event(exec, m_event_id);
     }
 
     void wait() const {
-        wait_event(m_event_id);
         if (m_event.has_value()) {
             m_event->wait_and_throw();
             m_event = std::nullopt;
         }
     }
 };
+
+template <>
+void impl_wait(const Kokkos::SYCL& exec, const Event<Kokkos::SYCL>& event) {
+    KOKKOS_EXPECTS(event.m_event.has_value());
+    exec.sycl_queue().submit([&](sycl::handler& cgh) { cgh.depends_on(*event.m_event); });
+}
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/event.hpp
+++ b/kokkos-execution/impl/event.hpp
@@ -20,12 +20,12 @@ namespace Kokkos::Execution::Impl {
 
 //! Constrain an @p EventType type to be a valid event type for @p Exec execution space type.
 template <typename EventType, typename Exec>
-concept event = Kokkos::ExecutionSpace<Exec> && std::default_initializable<EventType>
-             && std::constructible_from<EventType, const Exec&> && !std::copyable<EventType> && !std::movable<EventType>
-             && requires(EventType& obj, const Exec& exec) {
+concept event = Kokkos::ExecutionSpace<Exec> && std::default_initializable<EventType> && !std::copyable<EventType>
+             && !std::movable<EventType> && requires(EventType& obj, const Exec& exec) {
                     { obj.record(exec) } -> std::same_as<void>;
                 } && requires(const EventType& obj) {
                     { obj.wait() } -> std::same_as<void>;
+                    { obj.m_event_id } -> std::same_as<const uint64_t&>;
                 };
 
 //! An event that can be recorded on an execution space instance.
@@ -44,9 +44,10 @@ struct HasNonBlockingDispatch : std::false_type { };
 template <typename Exec>
 concept has_non_blocking_dispatch = HasNonBlockingDispatch<Exec>::value;
 
+static constexpr auto invalid_dev_id = Kokkos::Experimental::finite_max_v<uint32_t>;
 static constexpr auto invalid_event_id = Kokkos::Experimental::finite_max_v<uint64_t>;
 
-//! Event to be sent to @ref Kokkos::utils::callbacks::dispatch when an event is recorded on an execution space instance.
+//! Event to be sent to @ref Kokkos::utils::callbacks::dispatch when calling @ref record.
 struct RecordEvent {
     uint32_t dev_id = 0;
     uint64_t event_id = 0;
@@ -67,39 +68,32 @@ void record_event(const Exec& exec, uint64_t& event_id) {
 #endif
 }
 
-//! Event to be sent to @ref Kokkos::utils::callbacks::dispatch when an event is being waited for.
+//! Event to be sent to @ref Kokkos::utils::callbacks::dispatch when calling @ref wait.
 struct WaitEvent {
+    uint32_t dev_id = 0;
     uint64_t event_id = 0;
 
     constexpr auto operator<=>(const WaitEvent&) const = default;
 
     friend std::ostream& operator<<(std::ostream& out, const WaitEvent& event) {
-        return out << "WaitEvent: {event_id = " << event.event_id << '}';
+        return out << "WaitEvent: {dev_id = " << event.dev_id << ", event_id = " << event.event_id << '}';
     }
 };
 
-inline void wait_event(const uint64_t event_id) {
+template <Kokkos::ExecutionSpace Exec>
+void wait_event(const Event<Exec>& event) {
 #if defined(KOKKOS_EXECUTION_ENABLE_EVENT_DISPATCH)
-    Kokkos::utils::callbacks::dispatch(WaitEvent{.event_id = event_id});
+    Kokkos::utils::callbacks::dispatch(WaitEvent{.dev_id = invalid_dev_id, .event_id = event.m_event_id});
 #endif
 }
 
-} // namespace Kokkos::Execution::Impl
-
-#if defined(KOKKOS_ENABLE_CUDA)
-#    include "kokkos-execution/impl/Cuda/event.hpp"
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
+void wait_event(const ExecTo& exec, const Event<ExecFrom>& event) {
+#if defined(KOKKOS_EXECUTION_ENABLE_EVENT_DISPATCH)
+    Kokkos::utils::callbacks::dispatch(
+        WaitEvent{.dev_id = Kokkos::Tools::Experimental::device_id(exec), .event_id = event.m_event_id});
 #endif
-#if defined(KOKKOS_ENABLE_HIP)
-#    include "kokkos-execution/impl/HIP/event.hpp"
-#endif
-#if defined(KOKKOS_ENABLE_HPX)
-#    include "kokkos-execution/impl/HPX/event.hpp"
-#endif
-#if defined(KOKKOS_ENABLE_SYCL)
-#    include "kokkos-execution/impl/SYCL/event.hpp"
-#endif
-
-namespace Kokkos::Execution::Impl {
+}
 
 /**
  * @brief This is the default implementation. It assumes the backend has blocking dispatch.
@@ -118,24 +112,17 @@ struct Event {
     uint64_t m_event_id = invalid_event_id;
 
     Event() = default;
-
-    explicit Event(const Exec& exec) {
-        record(exec);
-    }
-
     Event(const Event&) = delete;
     Event& operator=(const Event&) = delete;
     Event(Event&&) noexcept = delete;
     Event& operator=(Event&&) noexcept = delete;
     ~Event() = default;
 
-    void record(const Exec& exec) {
+    void record(const Exec&) {
         m_recorded.store(true, std::memory_order_release);
-        record_event(exec, m_event_id);
     }
 
     void wait() const {
-        wait_event(m_event_id);
         /// The while loop is needed because the promise that memory writes that happened before the atomic store from
         /// the point of view of the recording thread become visible in the waiting thread only holds if the waiting thread
         /// actually reads the value that the recording thread stored.
@@ -145,6 +132,49 @@ struct Event {
     }
 };
 
+//! Record @p event on @p exec.
+template <Kokkos::ExecutionSpace Exec>
+void record(Event<Exec>& event, const Exec& exec) {
+    record_event(exec, event.m_event_id);
+    event.record(exec);
+}
+
+//! Wait for @p event to complete.
+template <Kokkos::ExecutionSpace Exec>
+void wait(const Event<Exec>& event) {
+    wait_event(event);
+    event.wait();
+}
+
+template <Kokkos::ExecutionSpace ExecFrom, Kokkos::ExecutionSpace ExecTo>
+void impl_wait(const ExecTo&, const Event<ExecFrom>& event) {
+    event.wait();
+}
+
+/**
+ * @brief The operations enqueued from the calling thread into @p exec cannot start before the event @p event completes.
+ *
+ * @note Backends should specialize @ref impl_wait.
+ */
+template <Kokkos::ExecutionSpace ExecFrom, Kokkos::ExecutionSpace ExecTo>
+void wait(const ExecTo& exec, const Event<ExecFrom>& event) {
+    wait_event(exec, event);
+    impl_wait(exec, event);
+}
+
 } // namespace Kokkos::Execution::Impl
+
+#if defined(KOKKOS_ENABLE_CUDA)
+#    include "kokkos-execution/impl/Cuda/event.hpp"
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+#    include "kokkos-execution/impl/HIP/event.hpp"
+#endif
+#if defined(KOKKOS_ENABLE_HPX)
+#    include "kokkos-execution/impl/HPX/event.hpp"
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+#    include "kokkos-execution/impl/SYCL/event.hpp"
+#endif
 
 #endif // KOKKOS_EXECUTION_IMPL_EVENT_HPP

--- a/tests/impl/test_event.cpp
+++ b/tests/impl/test_event.cpp
@@ -47,7 +47,9 @@ class EventTest
 //! @test Check that @ref Kokkos::Execution::Impl::Event satisfies @ref Kokkos::Execution::Impl::event.
 template <Kokkos::ExecutionSpace Exec>
 consteval bool test_models_event() {
-    return Kokkos::Execution::Impl::event<Kokkos::Execution::Impl::Event<Exec>, Exec>;
+    static_assert(Kokkos::Execution::Impl::event<Kokkos::Execution::Impl::Event<Exec>, Exec>);
+
+    return true;
 }
 static_assert(test_models_event<TEST_EXECUTION_SPACE>());
 
@@ -68,15 +70,15 @@ TEST(WaitEvent, description) {
     std::ostringstream oss;
     oss << event;
 
-    ASSERT_EQ(oss.str(), "WaitEvent: {event_id = 1337}");
+    ASSERT_EQ(oss.str(), "WaitEvent: {dev_id = 0, event_id = 1337}");
 }
 
 //! @test Record an event and wait for it. Check that it marks both steps.
 TEST_F(EventTest, record_and_wait) {
     const auto recorded_events = recorder_listener_t::record([this]() {
         Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
-        event.record(exec);
-        event.wait();
+        Kokkos::Execution::Impl::record(event, exec);
+        Kokkos::Execution::Impl::wait(event);
     });
 
     ASSERT_THAT(recorded_events, testing::SizeIs(2));
@@ -89,7 +91,7 @@ TEST_F(EventTest, record_but_dont_wait) {
     const auto recorded_events = recorder_listener_t::record([this]() {
         Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
         Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 1), Tests::Utils::Functors::NoOp{});
-        event.record(exec);
+        Kokkos::Execution::Impl::record(event, exec);
 
         exec.fence("some-label");
     });
@@ -103,12 +105,12 @@ TEST_F(EventTest, record_but_dont_wait) {
 TEST_F(EventTest, record_and_wait_many_times) {
     const auto recorded_events = recorder_listener_t::record([this]() {
         Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
-        event.record(exec);
-        event.wait();
-        event.wait();
-        event.wait();
-        event.wait();
-        event.wait();
+        Kokkos::Execution::Impl::record(event, exec);
+        Kokkos::Execution::Impl::wait(event);
+        Kokkos::Execution::Impl::wait(event);
+        Kokkos::Execution::Impl::wait(event);
+        Kokkos::Execution::Impl::wait(event);
+        Kokkos::Execution::Impl::wait(event);
     });
 
     ASSERT_THAT(recorded_events, ::testing::SizeIs(6));
@@ -124,10 +126,10 @@ TEST_F(EventTest, record_and_wait_many_times) {
 TEST_F(EventTest, record_and_wait_and_record_and_wait) {
     const auto recorded_events = recorder_listener_t::record([this]() {
         Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
-        event.record(exec);
-        event.wait();
-        event.record(exec);
-        event.wait();
+        Kokkos::Execution::Impl::record(event, exec);
+        Kokkos::Execution::Impl::wait(event);
+        Kokkos::Execution::Impl::record(event, exec);
+        Kokkos::Execution::Impl::wait(event);
     });
 
     ASSERT_THAT(recorded_events, ::testing::SizeIs(4));
@@ -143,9 +145,9 @@ TEST_F(EventTest, record_and_wait_and_record_and_wait) {
 TEST_F(EventTest, uniqueness) {
     const auto recorded_events = recorder_listener_t::record([this]() {
         Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event_before, event_after;
-        event_before.record(exec);
+        Kokkos::Execution::Impl::record(event_before, exec);
         Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, 1), Tests::Utils::Functors::NoOp{});
-        event_after.record(exec);
+        Kokkos::Execution::Impl::record(event_after, exec);
 
         exec.fence("some-label");
     });
@@ -169,13 +171,48 @@ TEST_F(EventTest, default_instance) {
 
     const auto recorded_events = recorder_listener_t::record([&default_exec]() {
         Kokkos::parallel_for(Kokkos::RangePolicy(default_exec, 0, 1), Tests::Utils::Functors::NoOp{});
-        const Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event{default_exec};
-        event.wait();
+        Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
+        Kokkos::Execution::Impl::record(event, default_exec);
+        Kokkos::Execution::Impl::wait(event);
     });
 
     ASSERT_THAT(recorded_events, ::testing::SizeIs(2));
     ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(default_exec));
     ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
+}
+
+//! @test Check @ref Kokkos::Execution::Impl::wait when the underlying execution space type is the same.
+TEST_F(EventTest, wait_exec_event_for_same_type) {
+    const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
+
+    const auto recorded_events = recorder_listener_t::record([&exec_A, &exec_B]() {
+        Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event_A;
+        Kokkos::Execution::Impl::record(event_A, exec_A);
+        Kokkos::Execution::Impl::wait(exec_B, event_A);
+    });
+
+    ASSERT_THAT(recorded_events, ::testing::SizeIs(2));
+    ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec_A));
+    ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(0)));
+}
+
+//! @test Check @ref Kokkos::Execution::Impl::wait when the underlying execution space type is different.
+TEST_F(EventTest, wait_exec_event_different_type) {
+    if constexpr (std::same_as<TEST_EXECUTION_SPACE, Kokkos::DefaultHostExecutionSpace>) {
+        GTEST_SKIP() << "The default host execution space is the same type as the test execution space.";
+    }
+
+    const Kokkos::DefaultHostExecutionSpace exec_h;
+
+    const auto recorded_events = recorder_listener_t::record([this, &exec_h]() {
+        Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event_d;
+        Kokkos::Execution::Impl::record(event_d, this->exec);
+        Kokkos::Execution::Impl::wait(exec_h, event_d);
+    });
+
+    ASSERT_THAT(recorded_events, ::testing::SizeIs(2));
+    ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(this->exec));
+    ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EXEC_EVENT(exec_h, recorded_events.at(0)));
 }
 
 /**
@@ -187,31 +224,38 @@ TEST_F(EventTest, default_instance) {
 TEST_F(EventTest, works_intended_usage_pattern) {
     constexpr size_t size = 128;
 
-    const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
+    const auto [exec_A, exec_B, exec_C] = Kokkos::Experimental::partition_space(exec, 1, 1, 1);
 
     const Kokkos::View<int, TEST_EXECUTION_SPACE> data(Kokkos::view_alloc(exec_A, "data"));
     const auto data_h = Kokkos::create_mirror_view(Kokkos::WithoutInitializing, data);
 
-    std::optional<Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE>> event;
+    std::optional<Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE>> event_A;
 
     stdexec::run_loop loop;
     std::thread consumer([&] { loop.run(); });
 
     Kokkos::parallel_for(
         Kokkos::RangePolicy(exec_A, 0, size), KOKKOS_LAMBDA(const auto idx) { Kokkos::atomic_add(&data(), idx); });
-    event.emplace(exec_A);
+    event_A.emplace();
+    Kokkos::Execution::Impl::record(*event_A, exec_A);
 
     bool upon_error = false;
 
     auto opstate = stdexec::connect(
         stdexec::schedule(loop.get_scheduler()) | stdexec::then([&] {
-            event->wait();
-            event.reset();
+            event_A->wait();
+            event_A.reset();
             Kokkos::parallel_for(
-                Kokkos::RangePolicy(exec_B, 0, 1),
-                KOKKOS_LAMBDA(const auto) { Kokkos::atomic_compare_exchange(&data(), size / 2 * (size - 1), 1); });
-            Kokkos::deep_copy(exec_B, data_h, data);
-            exec_B.fence("wait for the deep copy to complete");
+                Kokkos::RangePolicy(exec_B, 0, size),
+                KOKKOS_LAMBDA(const auto idx) { Kokkos::atomic_add(&data(), idx); });
+            Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event_B;
+            Kokkos::Execution::Impl::record(event_B, exec_B);
+            Kokkos::Execution::Impl::wait(exec_C, event_B);
+            Kokkos::parallel_for(
+                Kokkos::RangePolicy(exec_C, 0, 1),
+                KOKKOS_LAMBDA(const auto) { Kokkos::atomic_compare_exchange(&data(), size * (size - 1), 1); });
+            Kokkos::deep_copy(exec_C, data_h, data);
+            exec_C.fence("wait for the deep copy to complete");
             loop.finish();
         }) | stdexec::upon_error([&](const auto& eptr) {
             upon_error = true;
@@ -228,7 +272,7 @@ TEST_F(EventTest, works_intended_usage_pattern) {
 
     consumer.join();
 
-    ASSERT_FALSE(event.has_value());
+    ASSERT_FALSE(event_A.has_value());
 
 //! See @ref KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP for an explanation.
 #if defined(KOKKOS_ENABLE_THREADS)

--- a/tests/utils/callback_matchers.hpp
+++ b/tests/utils/callback_matchers.hpp
@@ -64,7 +64,18 @@ DEFINE_EVENT_MATCHER_IN(Kokkos::Execution::Impl, WaitEvent)
     AWaitEvent(                                                                                                        \
         ::testing::Field(                                                                                              \
             &Kokkos::Execution::Impl::WaitEvent::event_id,                                                             \
-            ::testing::Eq(std::get<Kokkos::Execution::Impl::RecordEvent>(_record_event_variant_).event_id)))
+            ::testing::Eq(std::get<Kokkos::Execution::Impl::RecordEvent>(_record_event_variant_).event_id)),           \
+        ::testing::Field(                                                                                              \
+            &Kokkos::Execution::Impl::WaitEvent::dev_id, ::testing::Eq(Kokkos::Execution::Impl::invalid_dev_id)))
+
+#define MATCHER_FOR_WAIT_EXEC_EVENT(_exec_, _record_event_variant_)                                                    \
+    AWaitEvent(                                                                                                        \
+        ::testing::Field(                                                                                              \
+            &Kokkos::Execution::Impl::WaitEvent::event_id,                                                             \
+            ::testing::Eq(std::get<Kokkos::Execution::Impl::RecordEvent>(_record_event_variant_).event_id)),           \
+        ::testing::Field(                                                                                              \
+            &Kokkos::Execution::Impl::WaitEvent::dev_id,                                                               \
+            ::testing::Eq(Kokkos::Tools::Experimental::device_id(_exec_))))
 // NOLINTEND(cppcoreguidelines-macro-usage)
 
 //! Matcher to filter out events that are just noise for tests.


### PR DESCRIPTION
This PR makes the following changes to existing implementations:
1. The `Event` specializations are not responsible for pushing the event record/wait to the event dispatcher.
2. Free functions must be used instead.

It also introduces `wait_for(exec, event)` which can be read as:
> `exec` must wait that `event` completes before any enqueue operation can be started.

From the CUDA API reference (`cudaStreamWaitForEvent`):
> Makes all future work submitted to stream wait for all work captured in event.

I don't think CUDA/HIP/SYCL guarantee more than "from the point of view of the calling thread".