### PR TITLE
tests: check that forwarding queries are properly forwarded through our customizations

### DIFF
--- a/tests/execution_space/test_bulk.cpp
+++ b/tests/execution_space/test_bulk.cpp
@@ -1,7 +1,10 @@
 #include "kokkos-utils/callbacks/RecorderListener.hpp"
 #include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
 
+#include "kokkos-execution/execution_space.hpp"
+
 #include "tests/utils/callback_matchers.hpp"
+#include "tests/utils/check_rcvr_env_queryable_with.hpp"
 #include "tests/utils/execution_space_context.hpp"
 #include "tests/utils/functors/counter.hpp"
 #include "tests/utils/functors/labeled.hpp"
@@ -11,6 +14,7 @@
 #include "tests/utils/sink_receiver.hpp"
 #include "tests/utils/stdexec.hpp"
 #include "tests/utils/sync_wait.hpp"
+#include "tests/utils/tracking_allocator.hpp"
 
 /**
  * @addtogroup unittests
@@ -210,6 +214,54 @@ TEST_F(BulkTest, no_spurious_copy_on_connect) {
         ASSERT_EQ(Tests::Utils::Functors::Counter::copy_constructions, 0);
         ASSERT_EQ(Tests::Utils::Functors::Counter::move_assignments, 0);
     }
+}
+
+/**
+ * @test The customization of @c stdexec::bulk properly forwards forwarding queries.
+ *
+ * @todo Too many synchronizations.
+ */
+TEST_F(BulkTest, forwarding_env) {
+    constexpr size_t size = 10;
+
+    const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
+
+    std::atomic<size_t> count = 0;
+
+    int value;
+
+    const context_t esc{exec};
+
+    stdexec::sender auto sndr =
+        stdexec::read_env(stdexec::get_allocator)
+        | stdexec::then([&value](auto allocator) { value = Tests::Utils::round_trip_allocate(allocator, 42); })
+        | stdexec::continues_on(esc.get_scheduler())
+        | Tests::Utils::check_rcvr_env_queryable_with<stdexec::get_allocator_t>() | BULK_SUM_INDICES(size, data)
+        | stdexec::write_env(stdexec::prop{stdexec::get_allocator, Tests::Utils::TrackingAllocator<int>{&count}});
+
+    ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
+
+    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
+
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::has_non_blocking_dispatch<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "bulk")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        } else {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "bulk")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        }
+    }());
+
+    ASSERT_EQ(data(), size / 2 * (size - 1));
+
+    ASSERT_EQ(value, 42);
+    ASSERT_EQ(count, 1);
 }
 
 } // namespace Tests::ExecutionSpaceImpl

--- a/tests/execution_space/test_parallel_for.cpp
+++ b/tests/execution_space/test_parallel_for.cpp
@@ -6,6 +6,7 @@
 #include "kokkos-execution/execution_space.hpp"
 
 #include "tests/utils/callback_matchers.hpp"
+#include "tests/utils/check_rcvr_env_queryable_with.hpp"
 #include "tests/utils/execution_space_context.hpp"
 #include "tests/utils/functors/load_check_add.hpp"
 #include "tests/utils/functors/no_op.hpp"
@@ -13,6 +14,7 @@
 #include "tests/utils/just_stopped.hpp"
 #include "tests/utils/sink_receiver.hpp"
 #include "tests/utils/sync_wait.hpp"
+#include "tests/utils/tracking_allocator.hpp"
 
 /**
  * @addtogroup unittests
@@ -341,6 +343,58 @@ TEST_F(ParallelForTest, starts_on_parallel_region) {
     }());
 
     ASSERT_EQ(witness(), size / 2 * (size - 1));
+}
+
+/**
+ * @test The customization of @ref Kokkos::Execution::parallel_for properly forwards forwarding queries.
+ *
+ * @todo Too many synchronizations.
+ */
+TEST_F(ParallelForTest, forwarding_env) {
+    constexpr size_t size = 10;
+
+    const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
+
+    std::atomic<size_t> count = 0;
+
+    int value;
+
+    const context_t esc{exec};
+
+    stdexec::sender auto sndr =
+        stdexec::read_env(stdexec::get_allocator)
+        | stdexec::then([&value](auto allocator) { value = Tests::Utils::round_trip_allocate(allocator, 42); })
+        | stdexec::continues_on(esc.get_scheduler())
+        | Tests::Utils::check_rcvr_env_queryable_with<stdexec::get_allocator_t>()
+        | Kokkos::Execution::parallel_for(
+            "my pfor",
+            Kokkos::RangePolicy<TEST_EXECUTION_SPACE>(0, size),
+            Tests::Utils::Functors::SumIndices{.data = data})
+        | stdexec::write_env(stdexec::prop{stdexec::get_allocator, Tests::Utils::TrackingAllocator<int>{&count}});
+
+    ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
+
+    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
+
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::has_non_blocking_dispatch<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, "my pfor"),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        } else {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, "my pfor"),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        }
+    }());
+
+    ASSERT_EQ(data(), size / 2 * (size - 1));
+
+    ASSERT_EQ(value, 42);
+    ASSERT_EQ(count, 1);
 }
 
 } // namespace Tests::ExecutionSpaceImpl

--- a/tests/execution_space/test_then.cpp
+++ b/tests/execution_space/test_then.cpp
@@ -4,6 +4,7 @@
 #include "kokkos-execution/execution_space.hpp"
 
 #include "tests/utils/callback_matchers.hpp"
+#include "tests/utils/check_rcvr_env_queryable_with.hpp"
 #include "tests/utils/execution_space_context.hpp"
 #include "tests/utils/functors/increment.hpp"
 #include "tests/utils/functors/no_op.hpp"
@@ -11,6 +12,7 @@
 #include "tests/utils/just_stopped.hpp"
 #include "tests/utils/stdexec.hpp"
 #include "tests/utils/sync_wait.hpp"
+#include "tests/utils/tracking_allocator.hpp"
 
 /**
  * @addtogroup unittests
@@ -308,5 +310,51 @@ consteval bool test_sndr_nothrow_transformable() {
     return true;
 }
 static_assert(test_sndr_nothrow_transformable());
+
+/**
+ * @test The customization of @c stdexec::then properly forwards forwarding queries.
+ *
+ * @todo Too many synchronizations.
+ */
+TEST_F(ThenTest, forwarding_env) {
+    const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
+
+    std::atomic<size_t> count = 0;
+
+    int value;
+
+    const context_t esc{exec};
+
+    stdexec::sender auto sndr =
+        stdexec::read_env(stdexec::get_allocator)
+        | stdexec::then([&value](auto allocator) { value = Tests::Utils::round_trip_allocate(allocator, 42); })
+        | stdexec::continues_on(esc.get_scheduler())
+        | Tests::Utils::check_rcvr_env_queryable_with<stdexec::get_allocator_t>() | THEN_INCREMENT(data)
+        | stdexec::write_env(stdexec::prop{stdexec::get_allocator, Tests::Utils::TrackingAllocator<int>{&count}});
+
+    ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
+
+    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
+
+    ASSERT_THAT(recorded_events, [&]() {
+        if constexpr (Kokkos::Execution::Impl::has_non_blocking_dispatch<TEST_EXECUTION_SPACE>) {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EVENT(recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        } else {
+            return testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait")));
+        }
+    }());
+
+    ASSERT_EQ(data(), 1);
+
+    ASSERT_EQ(value, 42);
+    ASSERT_EQ(count, 1);
+}
 
 } // namespace Tests::ExecutionSpaceImpl

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_one_test(NAME check_scheduler_type)
 add_one_test(NAME check_rcvr_env)
 add_one_test(NAME check_rcvr_env_queryable_with)
+add_one_test(NAME tracking_allocator)

--- a/tests/utils/test_tracking_allocator.cpp
+++ b/tests/utils/test_tracking_allocator.cpp
@@ -1,0 +1,55 @@
+#include "gtest/gtest.h"
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "tests/utils/tracking_allocator.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Tests for @c Tests::Utils::TrackingAllocator
+ * --------------------------------------------
+ *
+ * This group of tests check the behavior of @ref Tests::Utils::TrackingAllocator.
+ *
+ * The tests can be found in @ref tests/utils/test_tracking_allocator.cpp.
+ */
+
+namespace Tests {
+
+//! @test The allocator injected with @c stdexec::write_env is visible *via* @c stdexec::read_env.
+TEST(TrackingAllocatorTest, write_read_env) {
+    std::atomic<size_t> count = 0;
+
+    stdexec::sender auto sndr =
+        stdexec::read_env(stdexec::get_allocator) | stdexec::then([](auto allocator) {
+            int value = 42;
+            return Tests::Utils::round_trip_allocate(allocator, static_cast<int&>(value));
+        })
+        | stdexec::write_env(stdexec::prop{stdexec::get_allocator, Tests::Utils::TrackingAllocator<int>{&count}});
+
+    const auto [val] = stdexec::sync_wait(std::move(sndr)).value(); // NOLINT(performance-move-const-arg)
+
+    ASSERT_EQ(val, 42);
+    ASSERT_EQ(count, 1);
+}
+
+//! @test The allocator is forwarded through @c stdexec::then adaptor because @c stdexec::get_allocator_t is a forwarding query.
+TEST(TrackingAllocatorTest, forwarded_through_then) {
+    static_assert(stdexec::forwarding_query(stdexec::get_allocator));
+
+    std::atomic<size_t> count = 0;
+
+    stdexec::sender auto sndr =
+        stdexec::read_env(stdexec::get_allocator)
+        | stdexec::then([](auto allocator) { return Tests::Utils::round_trip_allocate(allocator, 42); })
+        | stdexec::then([](auto&& value) { return value; })
+        | stdexec::write_env(stdexec::prop{stdexec::get_allocator, Tests::Utils::TrackingAllocator<int>{&count}});
+
+    const auto [val] = stdexec::sync_wait(std::move(sndr)).value(); // NOLINT(performance-move-const-arg)
+
+    ASSERT_EQ(val, 42);
+    ASSERT_EQ(count, 1);
+}
+
+} // namespace Tests

--- a/tests/utils/tracking_allocator.hpp
+++ b/tests/utils/tracking_allocator.hpp
@@ -1,0 +1,57 @@
+#ifndef KOKKOS_EXECUTION_TESTS_UTILS_TRACKING_ALLOCATOR_HPP
+#define KOKKOS_EXECUTION_TESTS_UTILS_TRACKING_ALLOCATOR_HPP
+
+#include <atomic>
+#include <memory>
+#include <utility>
+
+namespace Tests::Utils {
+
+/**
+ * @brief A minimal tracking allocator.
+ *
+ * It atomically counts allocations.
+ */
+template <typename T>
+struct TrackingAllocator {
+    using value_type = T;
+
+    std::atomic<size_t>* count;
+
+    T* allocate(std::size_t n) {
+        ++(*count);
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* ptr, std::size_t size) {
+        std::allocator<T>{}.deallocate(ptr, size);
+    }
+
+    friend constexpr auto operator<=>(const TrackingAllocator&, const TrackingAllocator&) noexcept = default;
+};
+
+/**
+ * Allocate one @c T through @p alloc, copy construct in-place from @p value, then deallocate.
+ *
+ * @return The value that was copy-constructed.
+ */
+template <typename Allocator, typename T>
+auto round_trip_allocate(Allocator& allocator, T&& value) {
+    using traits = std::allocator_traits<Allocator>;
+
+    static_assert(std::same_as<typename traits::value_type, std::remove_cvref_t<T>>);
+
+    auto* ptr = traits::allocate(allocator, 1);
+
+    traits::construct(allocator, ptr, std::forward<T>(value));
+    std::remove_cvref_t<T> result = *ptr; // NOLINT(misc-const-correctness)
+
+    traits::destroy(allocator, ptr);
+    traits::deallocate(allocator, ptr, 1);
+
+    return result;
+}
+
+} // namespace Tests::Utils
+
+#endif // KOKKOS_EXECUTION_TESTS_UTILS_TRACKING_ALLOCATOR_HPP


### PR DESCRIPTION
Given how the forwarding is implemented currently:
https://github.com/NVIDIA/stdexec/blob/da7640aa1002cfcd665254f03434d3c949844361/include/stdexec/__detail/__env.hpp#L54-L71

we should not have any issue with forwarding queries not being forwarded. Yet, at least we now ensure this is always the case.