### PR TITLE
Impl: move `get_exec` from `ExecutionSpaceImpl`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ target_sources(
             kokkos-execution/execution_space/domain.hpp
             kokkos-execution/execution_space/env.hpp
             kokkos-execution/execution_space/execution_space_fwd.hpp
-            kokkos-execution/execution_space/get_exec.hpp
             kokkos-execution/execution_space/operation_state.hpp
             kokkos-execution/execution_space/parallel_for.hpp
             kokkos-execution/execution_space/schedule_from.hpp
@@ -120,6 +119,7 @@ target_sources(
             kokkos-execution/impl/dispatch_label.hpp
             kokkos-execution/impl/domain.hpp
             kokkos-execution/impl/env.hpp
+            kokkos-execution/impl/get_exec.hpp
             kokkos-execution/impl/event.hpp
             kokkos-execution/impl/HIP/event.hpp
             kokkos-execution/impl/HPX/event.hpp

--- a/kokkos-execution/execution_space.hpp
+++ b/kokkos-execution/execution_space.hpp
@@ -8,7 +8,6 @@
 #include "kokkos-execution/execution_space/bulk.hpp"
 #include "kokkos-execution/execution_space/continues_on.hpp"
 #include "kokkos-execution/execution_space/domain.hpp"
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/execution_space/parallel_for.hpp"
 #include "kokkos-execution/execution_space/schedule_from.hpp"
 #include "kokkos-execution/execution_space/scoped_region.hpp"

--- a/kokkos-execution/execution_space/continues_on.hpp
+++ b/kokkos-execution/execution_space/continues_on.hpp
@@ -2,7 +2,6 @@
 #define KOKKOS_EXECUTION_EXECUTION_SPACE_CONTINUES_ON_HPP
 
 #include "kokkos-execution/execution_space/env.hpp"
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/attributes.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
 

--- a/kokkos-execution/execution_space/env.hpp
+++ b/kokkos-execution/execution_space/env.hpp
@@ -3,7 +3,7 @@
 
 #include "kokkos-execution/stdexec.hpp"
 
-#include "kokkos-execution/execution_space/get_exec.hpp"
+#include "kokkos-execution/impl/get_exec.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
@@ -14,7 +14,7 @@ struct WithoutExecEnvPolicy { };
 template <typename Env, Kokkos::ExecutionSpace Exec>
 constexpr auto join_env_with_exec(Env&& env, const Exec& exec) noexcept {
     return stdexec::__env::__join(
-        stdexec::prop{get_exec, ExecutionSpaceRef{exec}}, stdexec::__fwd_env(std::forward<Env>(env)));
+        stdexec::prop{Impl::get_exec, Impl::ExecutionSpaceRef{exec}}, stdexec::__fwd_env(std::forward<Env>(env)));
 }
 
 //! Join @p exec to @p env if the policy is @ref WithExecEnvPolicy.
@@ -31,7 +31,7 @@ template <typename ExecEnvPolicy, typename Env, Kokkos::ExecutionSpace Exec>
 using join_env_with_exec_t = decltype(join_env_with_exec<ExecEnvPolicy>(std::declval<Env>(), std::declval<Exec>()));
 
 /**
- * If the policy is @ref WithExecEnvPolicy, extract the @ref ExecutionSpaceRef and re-inject it into the
+ * If the policy is @ref WithExecEnvPolicy, extract the @ref Impl::ExecutionSpaceRef and re-inject it into the
  * environment to extend its availability.
  *
  * @note This is not the same intent as using a forwarding query.
@@ -39,9 +39,9 @@ using join_env_with_exec_t = decltype(join_env_with_exec<ExecEnvPolicy>(std::dec
 template <typename ExecEnvPolicy, typename Env>
 constexpr auto extend_env(Env&& env) noexcept {
     if constexpr (std::same_as<ExecEnvPolicy, WithExecEnvPolicy>) {
-        auto ref = get_exec(env);
+        auto ref = Impl::get_exec(env);
         return stdexec::__env::__join(
-            stdexec::prop{get_exec, std::move(ref)}, stdexec::__fwd_env(std::forward<Env>(env)));
+            stdexec::prop{Impl::get_exec, std::move(ref)}, stdexec::__fwd_env(std::forward<Env>(env)));
     } else {
         return stdexec::__fwd_env(std::forward<Env>(env));
     }
@@ -50,10 +50,10 @@ constexpr auto extend_env(Env&& env) noexcept {
 template <typename ExecEnvPolicy, typename Env>
 using extend_env_t = decltype(extend_env<ExecEnvPolicy>(std::declval<Env>()));
 
-//! If @p Env is queryable with @ref get_exec_t, use @ref WithExecEnvPolicy.
+//! If @p Env is queryable with @ref Impl::get_exec_t, use @ref WithExecEnvPolicy.
 template <typename Env>
 using exec_env_policy_t =
-    std::conditional_t<stdexec::__queryable_with<Env, get_exec_t>, WithExecEnvPolicy, WithoutExecEnvPolicy>;
+    std::conditional_t<stdexec::__queryable_with<Env, Impl::get_exec_t>, WithExecEnvPolicy, WithoutExecEnvPolicy>;
 
 } // namespace Kokkos::Execution::ExecutionSpaceImpl
 

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -8,10 +8,10 @@
 #endif
 
 #include "kokkos-execution/execution_space/domain.hpp"
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/dispatch_label.hpp"
 #include "kokkos-execution/impl/env.hpp"
 #include "kokkos-execution/impl/event.hpp"
+#include "kokkos-execution/impl/get_exec.hpp"
 #include "kokkos-execution/impl/immovable.hpp"
 #include "kokkos-execution/impl/make_opstate.hpp"
 #include "kokkos-execution/impl/receiver.hpp"
@@ -55,19 +55,19 @@ struct RequiresSynchronization {
     }
 
     /**
-     * If the receiver environment can be queried for @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
+     * If the receiver environment can be queried for @ref Kokkos::Execution::Impl::get_exec_t,
      * and if the successor enqueues work on the same execution space instance, no synchronization is needed.
      */
     bool operator()(const OpState& opstate) const noexcept
-        requires(!successor_handles_sync && stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, get_exec_t>)
+        requires(!successor_handles_sync && stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>)
     {
         if constexpr (
             std::same_as<
-                std::remove_cvref_t<stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, get_exec_t>>,
-                stdexec::__query_result_t<OpState, get_exec_t>
+                std::remove_cvref_t<stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>>,
+                stdexec::__query_result_t<OpState, Impl::get_exec_t>
             >) {
-            const auto& src = opstate.query(get_exec).get();
-            const auto& dst = get_exec(stdexec::get_env(opstate.rcvr)).get();
+            const auto& src = opstate.query(Impl::get_exec).get();
+            const auto& dst = Impl::get_exec(stdexec::get_env(opstate.rcvr)).get();
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)
             PLOG_DEBUG << "The synchronization happens if " << Kokkos::Tools::Experimental::device_id(src)
                        << " is not equal to " << Kokkos::Tools::Experimental::device_id(dst) << '.';
@@ -79,7 +79,7 @@ struct RequiresSynchronization {
 
     //! As a fallback, synchronization is always required.
     constexpr bool operator()(const OpState&) const noexcept
-        requires(!successor_handles_sync && !stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, get_exec_t>)
+        requires(!successor_handles_sync && !stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>)
     {
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)
         PLOG_DEBUG << "Synchronization always required.";
@@ -131,7 +131,7 @@ struct MayDelegateCompletionWithEvent<Rcvr, Exec, false> {
     template <typename OpState>
     void delegate(OpState* const opstate) noexcept {
         if (RequiresSynchronization<Rcvr, OpState>{}(*opstate)) {
-            opstate->query(get_exec).get().fence(std::string(label));
+            opstate->query(Impl::get_exec).get().fence(std::string(label));
         }
         stdexec::set_value(std::move(this->rcvr));
     }
@@ -155,7 +155,7 @@ struct MayDelegateCompletionWithEvent<Rcvr, Exec, true> {
     void delegate(OpState* const opstate) noexcept {
         if (RequiresSynchronization<Rcvr, OpState>{}(*opstate)) {
             event.__construct();
-            Impl::record(event.__get(), opstate->query(get_exec).get());
+            Impl::record(event.__get(), opstate->query(Impl::get_exec).get());
             storage.__construct_from(
                 stdexec::connect,
                 stdexec::schedule(stdexec::get_delegation_scheduler(stdexec::get_env(this->rcvr))),
@@ -207,8 +207,8 @@ struct OpStateBase : public MayDelegateCompletionWithEvent<Rcvr, typename Clsr::
 
     //! @note All @ref clsrs are assumed to reference the same execution space instance.
     [[nodiscard]]
-    constexpr auto query(get_exec_t) const noexcept -> ExecutionSpaceRef<execution_space> {
-        return ExecutionSpaceRef<execution_space>{stdexec::__get<0>(clsrs).get_policy().space()};
+    constexpr auto query(Impl::get_exec_t) const noexcept -> Impl::ExecutionSpaceRef<execution_space> {
+        return Impl::ExecutionSpaceRef<execution_space>{stdexec::__get<0>(clsrs).get_policy().space()};
     }
 
     KOKKOS_EXECUTION_FORWARDING_GET_ENV(Rcvr, this->rcvr)

--- a/kokkos-execution/execution_space/schedule_from.hpp
+++ b/kokkos-execution/execution_space/schedule_from.hpp
@@ -6,10 +6,10 @@
 #include "kokkos-execution/execution_space/execution_space_fwd.hpp"
 
 #include "kokkos-execution/execution_space/env.hpp"
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/attributes.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
 #include "kokkos-execution/impl/env.hpp"
+#include "kokkos-execution/impl/get_exec.hpp"
 #include "kokkos-execution/impl/sender_introspection.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
@@ -26,18 +26,18 @@ struct ScheduleFromReceiver<WithDelegatedSyncPolicy, WithoutExecEnvPolicy, Schd,
     Rcvr rcvr;
 
     void set_value() && noexcept {
-        /// If the downstream receiver environment is queryable for @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec
+        /// If the downstream receiver environment is queryable for @ref Kokkos::Execution::Impl::get_exec
         /// and it shares the same execution space instance, skip the fence.
         const bool requires_synchronization = [&]() {
-            if constexpr (stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, get_exec_t>) {
+            if constexpr (stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>) {
                 if constexpr (
                     std::same_as<
                         typename std::remove_cvref_t<
-                            stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, get_exec_t>
+                            stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>
                         >::execution_space,
                         typename Schd::execution_space
                     >) {
-                    return get_exec(stdexec::get_env(rcvr)).get() != schd.state->exec;
+                    return Impl::get_exec(stdexec::get_env(rcvr)).get() != schd.state->exec;
                 }
             }
             return true;

--- a/kokkos-execution/execution_space/when_all.hpp
+++ b/kokkos-execution/execution_space/when_all.hpp
@@ -4,7 +4,7 @@
 #include "kokkos-execution/execution_space/execution_space_fwd.hpp"
 
 #include "kokkos-execution/execution_space/env.hpp"
-#include "kokkos-execution/execution_space/get_exec.hpp"
+#include "kokkos-execution/impl/get_exec.hpp"
 #include "kokkos-execution/stdexec.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
@@ -32,8 +32,7 @@ struct __sexpr_impl<Kokkos::Execution::ExecutionSpaceImpl::when_all_t> : stdexec
 
             if constexpr (std::same_as<exec_env_policy_t, Kokkos::Execution::ExecutionSpaceImpl::WithExecEnvPolicy>) {
                 return Kokkos::Execution::ExecutionSpaceImpl::join_env_with_exec(
-                    std::move(env),
-                    Kokkos::Execution::ExecutionSpaceImpl::get_exec(stdexec::get_env(state.__rcvr_)).get());
+                    std::move(env), Kokkos::Execution::Impl::get_exec(stdexec::get_env(state.__rcvr_)).get());
             } else {
                 return std::move(env);
             }

--- a/kokkos-execution/impl/get_exec.hpp
+++ b/kokkos-execution/impl/get_exec.hpp
@@ -1,9 +1,9 @@
-#ifndef KOKKOS_EXECUTION_EXECUTION_SPACE_GET_EXEC_HPP
-#define KOKKOS_EXECUTION_EXECUTION_SPACE_GET_EXEC_HPP
+#ifndef KOKKOS_EXECUTION_IMPL_GET_EXEC_HPP
+#define KOKKOS_EXECUTION_IMPL_GET_EXEC_HPP
 
 #include "Kokkos_Core.hpp"
 
-namespace Kokkos::Execution::ExecutionSpaceImpl {
+namespace Kokkos::Execution::Impl {
 
 /**
  * Query an object for its @c Kokkos execution space instance.
@@ -52,6 +52,6 @@ struct ExecutionSpaceRef {
     }
 };
 
-} // namespace Kokkos::Execution::ExecutionSpaceImpl
+} // namespace Kokkos::Execution::Impl
 
-#endif // KOKKOS_EXECUTION_EXECUTION_SPACE_GET_EXEC_HPP
+#endif // KOKKOS_EXECUTION_IMPL_GET_EXEC_HPP

--- a/kokkos-execution/impl/sync_wait.hpp
+++ b/kokkos-execution/impl/sync_wait.hpp
@@ -3,7 +3,6 @@
 
 #include "kokkos-execution/stdexec.hpp"
 
-#include "kokkos-execution/execution_space/get_exec.hpp"
 #include "kokkos-execution/impl/dispatch_label.hpp"
 #include "kokkos-execution/impl/sender_introspection.hpp"
 #include "kokkos-execution/impl/state.hpp"

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -68,7 +68,7 @@ consteval bool test_continues_on_sndr_traits() {
 }
 static_assert(test_continues_on_sndr_traits());
 
-//! @test Check that the @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec_t query is forwarded as expected.
+//! @test Check that the @ref Kokkos::Execution::Impl::get_exec_t query is forwarded as expected.
 TEST_F(ContinuesOnTest, queryable_get_exec) {
     const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
 
@@ -79,11 +79,8 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
 
     auto schs_A = stdexec::schedule(esc_A.get_scheduler());
 
-    //! The schedule sender environment is not queryable with @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec_t.
-    static_assert(!stdexec::__queryable_with<
-                  decltype(stdexec::get_env(schs_A)),
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
-    >);
+    //! The schedule sender environment is not queryable with @ref Kokkos::Execution::Impl::get_exec_t.
+    static_assert(!stdexec::__queryable_with<decltype(stdexec::get_env(schs_A)), Kokkos::Execution::Impl::get_exec_t>);
 
     auto schs_A_then = std::move(schs_A) | THEN_LABELED('A'); // NOLINT(performance-move-const-arg)
 
@@ -133,7 +130,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
 
     /**
      * The environment of the receiver created by the customization of the most downstream @c then
-     * is queryable with @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec_t.
+     * is queryable with @ref Kokkos::Execution::Impl::get_exec_t.
      */
     using then_rcvr_t = Kokkos::Execution::Impl::Receiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
         Kokkos::Execution::Impl::SyncWait::Receiver<host_execution_space>,
@@ -144,8 +141,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         >
     >>;
     static_assert(std::same_as<decltype(op_state.inner_opstate.rcvr.rcvr.rcvr), then_rcvr_t>);
-    static_assert(
-        !stdexec::__queryable_with<stdexec::env_of_t<then_rcvr_t>, Kokkos::Execution::ExecutionSpaceImpl::get_exec_t>);
+    static_assert(!stdexec::__queryable_with<stdexec::env_of_t<then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
 
     //! Our customization of @c continues_on forwards the environment.
     using con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<
@@ -154,25 +150,20 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         then_rcvr_t
     >;
     static_assert(std::same_as<decltype(op_state.inner_opstate.rcvr.rcvr), con_h_then_rcvr_t>);
-    static_assert(stdexec::__queryable_with<
-                  stdexec::env_of_t<con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
-    >);
+    static_assert(stdexec::__queryable_with<stdexec::env_of_t<con_h_then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
     static_assert(std::same_as<
                   stdexec::env_of_t<con_h_then_rcvr_t>,
                   stdexec::env<
                       stdexec::prop<
-                          Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
-                          Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<host_execution_space>
+                          Kokkos::Execution::Impl::get_exec_t,
+                          Kokkos::Execution::Impl::ExecutionSpaceRef<host_execution_space>
                       >,
                       stdexec::__env::__fwd<Kokkos::Execution::Impl::SyncWait::env>
                   >
     >);
-    ASSERT_EQ(
-        Kokkos::Execution::ExecutionSpaceImpl::get_exec(stdexec::get_env(op_state.inner_opstate.rcvr.rcvr)).get(),
-        exec_h);
+    ASSERT_EQ(Kokkos::Execution::Impl::get_exec(stdexec::get_env(op_state.inner_opstate.rcvr.rcvr)).get(), exec_h);
 
-    //! @ref Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver updates the @ref Kokkos::Execution::ExecutionSpaceImpl::get_exec_t query.
+    //! @ref Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver updates the @ref Kokkos::Execution::Impl::get_exec_t query.
     using sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver<
         Kokkos::Execution::ExecutionSpaceImpl::WithDelegatedSyncPolicy,
         Kokkos::Execution::ExecutionSpaceImpl::WithoutExecEnvPolicy,
@@ -180,10 +171,8 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         con_h_then_rcvr_t
     >;
     static_assert(std::same_as<decltype(op_state.inner_opstate.rcvr), sfrom_con_h_then_rcvr_t>);
-    static_assert(!stdexec::__queryable_with<
-                  stdexec::env_of_t<sfrom_con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
-    >);
+    static_assert(
+        !stdexec::__queryable_with<stdexec::env_of_t<sfrom_con_h_then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
 
     using then_sfrom_con_h_then_rcvr_t =
         Kokkos::Execution::Impl::Receiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
@@ -198,7 +187,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         std::same_as<decltype(op_state.inner_opstate.inner_opstate.rcvr.rcvr.rcvr), then_sfrom_con_h_then_rcvr_t>);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<then_sfrom_con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
+                  Kokkos::Execution::Impl::get_exec_t
     >);
 
     using con_B_then_sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<
@@ -210,28 +199,26 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         std::same_as<decltype(op_state.inner_opstate.inner_opstate.rcvr.rcvr), con_B_then_sfrom_con_h_then_rcvr_t>);
     static_assert(stdexec::__queryable_with<
                   stdexec::env_of_t<con_B_then_sfrom_con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
+                  Kokkos::Execution::Impl::get_exec_t
     >);
     static_assert(std::same_as<
                   stdexec::env_of_t<con_B_then_sfrom_con_h_then_rcvr_t>,
                   stdexec::env<
                       stdexec::prop<
-                          Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
-                          Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<TEST_EXECUTION_SPACE>
+                          Kokkos::Execution::Impl::get_exec_t,
+                          Kokkos::Execution::Impl::ExecutionSpaceRef<TEST_EXECUTION_SPACE>
                       >,
                       stdexec::__env::__fwd<stdexec::env<
                           stdexec::prop<
-                              Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
-                              Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<host_execution_space>
+                              Kokkos::Execution::Impl::get_exec_t,
+                              Kokkos::Execution::Impl::ExecutionSpaceRef<host_execution_space>
                           >,
                           stdexec::__env::__fwd<Kokkos::Execution::Impl::SyncWait::env>
                       >>
                   >
     >);
     ASSERT_EQ(
-        Kokkos::Execution::ExecutionSpaceImpl::get_exec(
-            stdexec::get_env(op_state.inner_opstate.inner_opstate.rcvr.rcvr))
-            .get(),
+        Kokkos::Execution::Impl::get_exec(stdexec::get_env(op_state.inner_opstate.inner_opstate.rcvr.rcvr)).get(),
         exec_B);
 
     using sfrom_con_B_then_sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver<
@@ -244,7 +231,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
         std::same_as<decltype(op_state.inner_opstate.inner_opstate.rcvr), sfrom_con_B_then_sfrom_con_h_then_rcvr_t>);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<sfrom_con_B_then_sfrom_con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
+                  Kokkos::Execution::Impl::get_exec_t
     >);
 
     using then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t =
@@ -262,7 +249,7 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
     >);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t>,
-                  Kokkos::Execution::ExecutionSpaceImpl::get_exec_t
+                  Kokkos::Execution::Impl::get_exec_t
     >);
 }
 
@@ -376,15 +363,15 @@ TEST_F(ContinuesOnTest, transition_to_another_execution_space_instance_and_back_
     using level_C_env_t = Kokkos::Execution::Impl::SyncWait::env;
     using level_B_env_t = stdexec::__env::__fwd<stdexec::env<
         stdexec::prop<
-            Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<TEST_EXECUTION_SPACE>
+            Kokkos::Execution::Impl::get_exec_t,
+            Kokkos::Execution::Impl::ExecutionSpaceRef<TEST_EXECUTION_SPACE>
         >,
         stdexec::__env::__fwd<level_C_env_t>
     >>;
     using level_A_env_t = stdexec::__env::__fwd<stdexec::env<
         stdexec::prop<
-            Kokkos::Execution::ExecutionSpaceImpl::get_exec_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ExecutionSpaceRef<host_execution_space>
+            Kokkos::Execution::Impl::get_exec_t,
+            Kokkos::Execution::Impl::ExecutionSpaceRef<host_execution_space>
         >,
         level_B_env_t
     >>;

--- a/tests/execution_space/test_operation_state.cpp
+++ b/tests/execution_space/test_operation_state.cpp
@@ -140,7 +140,7 @@ TEST_F(OpStateTest, construct_query_and_start) {
     auto op_state = Kokkos::Execution::ExecutionSpaceImpl::OpState{
         stdexec::schedule(esc.get_scheduler()), Tests::Utils::SinkReceiver{}, std::move(clsr)};
 
-    ASSERT_EQ(Kokkos::Execution::ExecutionSpaceImpl::get_exec(op_state).get(), exec);
+    ASSERT_EQ(Kokkos::Execution::Impl::get_exec(op_state).get(), exec);
 
     op_state.start();
     exec.fence();

--- a/tests/execution_space/test_when_all.cpp
+++ b/tests/execution_space/test_when_all.cpp
@@ -426,14 +426,13 @@ TEST_F(WhenAllTest, nested_with_inner_followed_by_other) {
     const context_t esc{exec};
     experimental::execution::single_thread_context stc{};
 
-    auto sndr =
-        stdexec::when_all(
-            stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
-            stdexec::when_all(stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
-                | Tests::Utils::check_rcvr_env_not_queryable_with<Kokkos::Execution::ExecutionSpaceImpl::get_exec_t>()
-                | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
-                | stdexec::continues_on(esc.get_scheduler()))
-        | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
+    auto sndr = stdexec::when_all(
+                    stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data),
+                    stdexec::when_all(stdexec::schedule(esc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data))
+                        | Tests::Utils::check_rcvr_env_not_queryable_with<Kokkos::Execution::Impl::get_exec_t>()
+                        | stdexec::continues_on(stc.get_scheduler()) | THEN_INCREMENT_ATOMIC(data)
+                        | stdexec::continues_on(esc.get_scheduler()))
+              | stdexec::continues_on(esc.get_scheduler()) | THEN_INCREMENT(data);
 
     ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
 


### PR DESCRIPTION
This PR moves `get_exec` from `ExecutionSpaceImpl` to `Impl`.