### PR TITLE
graph: automatically determine if the node is a root when creating the event

### DIFF
--- a/kokkos-execution/graph/events.hpp
+++ b/kokkos-execution/graph/events.hpp
@@ -106,16 +106,39 @@ auto create_graph(const Kokkos::Impl::DeviceHandle<Exec>& device_handle, Args&&.
 /**
  * @brief Record an event for a @p node added after @p predecessor.
  *
- * @todo There is no way to tell if the predecessor is a root node.
+ * @todo Use https://github.com/kokkos/kokkos/pull/9170 to determine if the predecessor is a root node.
  */
-template <bool IsRoot, NodeRef Predecessor, NodeRef NodeType>
+template <NodeRef Predecessor, NodeRef NodeType>
 void graph_add_node_event(const Predecessor& predecessor, const NodeType& node) {
 #if defined(KOKKOS_EXECUTION_ENABLE_EVENT_DISPATCH)
     auto* const node_ptr = get_node_ptr(node);
+    auto* const pred_ptr = get_node_ptr(predecessor);
+    auto* const graph_ptr = get_graph_impl_ptr(predecessor);
+
+    // NOLINTBEGIN(bugprone-branch-clone)
+    constexpr bool is_root = []() {
+        using aggregate_t = decltype(graph_ptr->create_aggregate_ptr());
+
+        if constexpr (requires { typename std::remove_cvref_t<decltype(*pred_ptr)>::kernel_type; }) {
+            using kernel_t = typename std::remove_cvref_t<decltype(*pred_ptr)>::kernel_type;
+            if constexpr (Kokkos::Impl::is_graph_kernel_v<kernel_t>) {
+                return false;
+            } else if constexpr (Kokkos::Impl::is_graph_capture_v<kernel_t>) {
+                return false;
+            } else if constexpr (Kokkos::Impl::is_graph_then_host_v<kernel_t>) {
+                return false;
+            }
+        } else if constexpr (std::same_as<Predecessor, aggregate_t>) {
+            return false;
+        }
+        return true;
+    }();
+    // NOLINTEND(bugprone-branch-clone)
+
     Kokkos::utils::callbacks::dispatch(
         GraphAddNodeEvent{
-            .graph = get_graph_impl_ptr(predecessor),
-            .predecessor = IsRoot ? nullptr : get_node_ptr(predecessor),
+            .graph = graph_ptr,
+            .predecessor = is_root ? nullptr : pred_ptr,
             .node = node_ptr,
             .dev_id = Kokkos::Tools::Experimental::device_id(node_ptr->get_device_handle().m_exec)});
 #endif

--- a/kokkos-execution/graph/operation_state.hpp
+++ b/kokkos-execution/graph/operation_state.hpp
@@ -91,14 +91,14 @@ struct OpStateBase {
 };
 
 //! Add all nodes as a sequence. Hence, only the first node may be added after the root node.
-template <bool PredecessorIsRoot, NodeRef Predecessor, Closure FirstClosure, Closure... RestOfClosures>
+template <typename Predecessor, Closure FirstClosure, Closure... RestOfClosures>
+requires NodeRef<std::remove_cvref_t<Predecessor>>
 static auto add_nodes(Predecessor&& predecessor, FirstClosure&& clsr, RestOfClosures&&... clsrs) {
-    auto node = std::forward<FirstClosure>(clsr)
-                    .template add_node<PredecessorIsRoot>(std::forward<Predecessor>(predecessor));
+    auto node = std::forward<FirstClosure>(clsr).add_node(std::forward<Predecessor>(predecessor));
     if constexpr (sizeof...(RestOfClosures) == 0) {
         return node;
     } else {
-        return add_nodes<false>(std::move(node), std::forward<RestOfClosures>(clsrs)...);
+        return add_nodes(std::move(node), std::forward<RestOfClosures>(clsrs)...);
     }
 }
 
@@ -123,7 +123,7 @@ struct OpState
 
     static constexpr bool after_root = std::same_as<graph_composition_policy_t, GraphComposition::Create>;
 
-    using node_t = decltype(add_nodes<after_root>(
+    using node_t = decltype(add_nodes(
         std::declval<predecessor_t>(),
         std::declval<FirstClosure>(),
         std::declval<RestOfClosures>()...));
@@ -141,7 +141,7 @@ struct OpState
         : OpStateBase<execution_space, Rcvr>(std::move(rcvr))
         , inner_opstate(stdexec::connect(std::forward<Sndr>(sndr), rcvr_t{this}))
         , state{Kokkos::Impl::get_property<device_handle_t>(clsr.node_props)}
-        , node{add_nodes<after_root>(this->get_predecessor(), std::move(clsr), std::move(clsrs)...)} {
+        , node{add_nodes(this->get_predecessor(), std::move(clsr), std::move(clsrs)...)} {
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)
         PLOG_INFO << "Operation state graph composition policy is "
                   << Kokkos::Impl::TypeInfo<graph_composition_policy_t>::name()

--- a/kokkos-execution/graph/parallel_for.hpp
+++ b/kokkos-execution/graph/parallel_for.hpp
@@ -24,12 +24,12 @@ struct ParallelForClosure {
         std::declval<Functor&&>()));
 
     //! @warning Unconditionally **not** @c noexcept because adding a node may throw.
-    template <bool PredecessorIsRoot, NodeRef Predecessor>
+    template <NodeRef Predecessor>
     auto add_node(const Predecessor& predecessor) && noexcept(false) -> node_t<Predecessor> {
         auto node = predecessor.then_parallel_for(
             std::move(node_props), std::forward<ExecPolicy>(policy), std::forward<Functor>(functor));
         KOKKOS_EXECUTION_IMPL_GRAPH_ADD_NODE_DEBUG_LOGGING("parallel_for", node, predecessor)
-        graph_add_node_event<PredecessorIsRoot>(predecessor, node);
+        graph_add_node_event(predecessor, node);
         return node;
     }
     node_props_t node_props;

--- a/kokkos-execution/graph/then.hpp
+++ b/kokkos-execution/graph/then.hpp
@@ -34,11 +34,11 @@ struct ThenClosure {
                                 .then(std::declval<node_props_t&&>(), std::declval<Functor&&>()));
 
     //! @warning Unconditionally **not** @c noexcept because adding a node may throw.
-    template <bool PredecessorIsRoot, NodeRef Predecessor>
+    template <NodeRef Predecessor>
     auto add_node(const Predecessor& predecessor) && noexcept(false) -> node_t<Predecessor> {
         auto node = predecessor.then(std::move(node_props), std::forward<Functor>(functor));
         KOKKOS_EXECUTION_IMPL_GRAPH_ADD_NODE_DEBUG_LOGGING("then", node, predecessor)
-        graph_add_node_event<PredecessorIsRoot>(predecessor, node);
+        graph_add_node_event(predecessor, node);
         return node;
     }
     node_props_t node_props;

--- a/tests/graph/test_events.cpp
+++ b/tests/graph/test_events.cpp
@@ -54,7 +54,7 @@ consteval bool test_noexcept() {
     static_assert(
         !noexcept(Kokkos::Execution::GraphImpl::create_graph(std::declval<const EventsTest::device_handle_t&>())));
 
-    static_assert(!noexcept(Kokkos::Execution::GraphImpl::graph_add_node_event<true>(
+    static_assert(!noexcept(Kokkos::Execution::GraphImpl::graph_add_node_event(
         std::declval<const EventsTest::graph_t::root_t&>(), std::declval<const EventsTest::graph_t::root_t&>())));
 
     static_assert(
@@ -97,10 +97,10 @@ TEST_F(EventsTest, create_and_add_nodes) {
         const auto root = graph.root_node();
 
         const auto node_A = root.then(Kokkos::Experimental::node_props(device_handle), KOKKOS_LAMBDA(){});
-        Kokkos::Execution::GraphImpl::graph_add_node_event<true>(root, node_A);
+        Kokkos::Execution::GraphImpl::graph_add_node_event(root, node_A);
 
         const auto node_B = node_A.then(Kokkos::Experimental::node_props(device_handle), KOKKOS_LAMBDA(){});
-        Kokkos::Execution::GraphImpl::graph_add_node_event<false>(node_A, node_B);
+        Kokkos::Execution::GraphImpl::graph_add_node_event(node_A, node_B);
     });
     ASSERT_THAT(
         recorded_events,


### PR DESCRIPTION
Instead of forcing the user to pass a non-type template boolean value.

Temporary solution until we get:
* https://github.com/kokkos/kokkos/pull/9170

The very benefit of this PR is to relieve our implementation from tracking with a non-type boolean template value if the node is a root, just for the sake of recording events.