### PR TITLE
(ExecutionSpace/Graph)Impl: evolve `continues_after` to `submitted`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ target_sources(
             kokkos-execution/impl/HPX/event.hpp
             kokkos-execution/impl/immovable.hpp
             kokkos-execution/impl/make_opstate.hpp
+            kokkos-execution/impl/optional_ref.hpp
             kokkos-execution/impl/optional_storage.hpp
             kokkos-execution/impl/receiver.hpp
             kokkos-execution/impl/sender_concepts.hpp
@@ -133,6 +134,7 @@ target_sources(
             kokkos-execution/impl/SYCL/event.hpp
             kokkos-execution/impl/schedulers.hpp
             kokkos-execution/impl/state.hpp
+            kokkos-execution/impl/submitted.hpp
             kokkos-execution/impl/sync_wait.hpp
             kokkos-execution/impl/type_traits.hpp
             kokkos-execution/utils/ignore_warnings.hpp

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -11,6 +11,7 @@
 #include "kokkos-execution/impl/make_opstate.hpp"
 #include "kokkos-execution/impl/receiver.hpp"
 #include "kokkos-execution/impl/sender_concepts.hpp"
+#include "kokkos-execution/impl/submitted.hpp"
 #include "kokkos-execution/impl/sync_wait.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
@@ -28,13 +29,11 @@ concept Closure = requires(const Clsr& clsr) {
 };
 
 template <typename Exec, typename Rcvr>
-consteval auto select_sync_policy() {
-    if constexpr (
-        stdexec::__is_instance_of<Rcvr, Impl::SyncWait::Receiver>
-        || stdexec::__is_instance_of<Rcvr, ScheduleFromReceiver>) {
-        return Impl::SyncPolicy::PassThrough{};
-    } else if constexpr (Impl::deferred_completion_receiver<Rcvr, Exec>) {
-        return Impl::SyncPolicy::DeferWaitEvent{};
+consteval auto select_completion_signal_policy() {
+    if constexpr (Impl::supports_submitted_order_on<Rcvr>) {
+        return Impl::SubmittedPolicy::OrderOnExec{};
+    } else if constexpr (Impl::supports_submitted_depend_on<Rcvr, Exec>) {
+        return Impl::SubmittedPolicy::DependOnEvent{};
     } else if constexpr (
         Impl::has_non_blocking_dispatch<Exec>
         && stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, stdexec::get_delegation_scheduler_t>) {
@@ -44,16 +43,13 @@ consteval auto select_sync_policy() {
     }
 }
 
-template <typename Exec, typename Rcvr>
-using select_sync_policy_t = decltype(select_sync_policy<Exec, Rcvr>());
-
 template <stdexec::receiver Rcvr, Closure Clsr, Closure... Clsrs>
 requires(std::same_as<typename Clsr::execution_space, typename Clsrs::execution_space> && ...)
 struct OpStateBase {
     using execution_space = typename Clsr::execution_space;
 
-    using sync_policy_t = select_sync_policy_t<execution_space, Rcvr>;
-    using completion_signal_t = Impl::CompletionSignal<sync_policy_t, execution_space, Rcvr>;
+    using completion_signal_policy_t = decltype(select_completion_signal_policy<execution_space, Rcvr>());
+    using completion_signal_t = Impl::CompletionSignal<completion_signal_policy_t, execution_space, Rcvr>;
     using closures_t = stdexec::__tuple<Clsr, Clsrs...>;
 
     completion_signal_t completion_signal;
@@ -66,23 +62,23 @@ struct OpStateBase {
         , clsrs(std::move(clsr_), std::move(clsrs_)...) {
     }
 
-    void complete(stdexec::set_value_t) noexcept {
+    template <typename Error>
+    void complete(stdexec::set_error_t, Error&& error) noexcept {
+        stdexec::set_error(std::move(completion_signal.rcvr), std::forward<Error>(error));
+    }
+
+    void complete(stdexec::set_stopped_t) noexcept {
+        stdexec::set_stopped(std::move(completion_signal.rcvr));
+    }
+
+    void submit() noexcept {
         try {
             stdexec::__apply([](auto&... clsr) { (clsr.submit(), ...); }, clsrs);
         } catch (...) {
             this->complete(stdexec::set_error, std::current_exception());
             return;
         }
-        completion_signal.propagate(stdexec::set_value, this->query(Impl::get_exec).get());
-    }
-
-    template <typename Error>
-    void complete(stdexec::set_error_t, Error&& error) noexcept {
-        completion_signal.propagate(stdexec::set_error, std::forward<Error>(error));
-    }
-
-    void complete(stdexec::set_stopped_t) noexcept {
-        completion_signal.propagate(stdexec::set_stopped);
+        completion_signal.propagate(this->query(Impl::get_exec).get());
     }
 
     //! @note All @ref clsrs are assumed to reference the same execution space instance.
@@ -102,7 +98,7 @@ requires(!Impl::dispatching_sender<Sndr>)
 struct OpState
     : public Impl::Immovable
     , public OpStateBase<Rcvr, Clsrs...> {
-    using operation_state_concept = stdexec::operation_state_tag;
+    using operation_state_concept = Impl::SubmittedOperationStateTag;
 
     using base_t = OpStateBase<Rcvr, Clsrs...>;
     using rcvr_t = Impl::Receiver<base_t>;

--- a/kokkos-execution/execution_space/schedule_from.hpp
+++ b/kokkos-execution/execution_space/schedule_from.hpp
@@ -20,7 +20,7 @@ struct WithoutDelegatedSyncPolicy { };
 //! Receiver for @c schedule_from.
 template <stdexec::scheduler Schd, stdexec::receiver Rcvr>
 struct ScheduleFromReceiver<WithDelegatedSyncPolicy, WithoutExecEnvPolicy, Schd, Rcvr> {
-    using receiver_concept = Impl::DeferredCompletionReceiverTag;
+    using receiver_concept = Impl::SubmittedReceiverTag;
 
     Schd schd;
     Rcvr rcvr;
@@ -29,7 +29,7 @@ struct ScheduleFromReceiver<WithDelegatedSyncPolicy, WithoutExecEnvPolicy, Schd,
         stdexec::set_value(std::move(rcvr));
     }
 
-    void continues_after() && noexcept {
+    void submitted() && noexcept {
         /// If the downstream receiver environment is queryable for @ref Kokkos::Execution::Impl::get_exec
         /// and it shares the same execution space instance, skip the fence.
         const bool requires_synchronization = [&]() {

--- a/kokkos-execution/graph/operation_state.hpp
+++ b/kokkos-execution/graph/operation_state.hpp
@@ -20,6 +20,7 @@
 #include "kokkos-execution/impl/make_opstate.hpp"
 #include "kokkos-execution/impl/receiver.hpp"
 #include "kokkos-execution/impl/sender_concepts.hpp"
+#include "kokkos-execution/impl/submitted.hpp"
 
 namespace Kokkos::Execution::GraphImpl {
 
@@ -67,8 +68,8 @@ struct State<GraphComposition::Create, Exec> {
  */
 template <Kokkos::ExecutionSpace Exec, stdexec::receiver Rcvr>
 struct OpStateBase {
-    using sync_policy_t = Impl::SyncPolicy::PassThrough;
-    using completion_signal_t = Impl::CompletionSignal<sync_policy_t, Exec, Rcvr>;
+    using completion_signal_policy_t = Impl::SyncPolicy::InlineFenceExec;
+    using completion_signal_t = Impl::CompletionSignal<completion_signal_policy_t, Exec, Rcvr>;
 
     completion_signal_t completion_signal;
 
@@ -76,17 +77,13 @@ struct OpStateBase {
         : completion_signal(std::move(rcvr)) {
     }
 
-    void complete(stdexec::set_value_t) noexcept {
-        completion_signal.propagate(stdexec::set_value);
-    }
-
     template <typename Error>
     void complete(stdexec::set_error_t, Error&& error) noexcept {
-        completion_signal.propagate(stdexec::set_error, std::forward<Error>(error));
+        stdexec::set_error(std::move(completion_signal.rcvr), std::forward<Error>(error));
     }
 
     void complete(stdexec::set_stopped_t) noexcept {
-        completion_signal.propagate(stdexec::set_stopped);
+        stdexec::set_stopped(std::move(completion_signal.rcvr));
     }
 };
 
@@ -107,7 +104,7 @@ template <stdexec::sender Sndr, stdexec::receiver Rcvr, Closure FirstClosure, Cl
 struct OpState
     : public Impl::Immovable
     , public OpStateBase<typename FirstClosure::execution_space, Rcvr> {
-    using operation_state_concept = stdexec::operation_state_tag;
+    using operation_state_concept = Impl::SubmittedOperationStateTag;
 
     using execution_space = typename FirstClosure::execution_space;
     using device_handle_t = typename FirstClosure::device_handle_t;
@@ -170,18 +167,15 @@ struct OpState
         }
     }
 
-    void complete(stdexec::set_value_t) noexcept {
+    void submit() noexcept {
         if constexpr (after_root) {
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)
             PLOG_INFO << "Submitting graph " << get_graph_impl_ptr(state.graph.root_node()) << " on "
                       << Kokkos::Tools::Experimental::device_id(state.get_device_handle().m_exec) << '.';
 #endif
             submit_graph(state.graph, state.get_device_handle().m_exec);
-
-            //! @bug This synchronization should be carried out elsewhere.
-            state.get_device_handle().m_exec.fence(std::string(Impl::dispatch_label<execution_space, ": sync_wait">()));
         }
-        OpStateBase<execution_space, Rcvr>::complete(stdexec::set_value);
+        this->completion_signal.propagate(state.get_device_handle().m_exec);
     }
 
     const auto& query(get_node_t) const & noexcept {

--- a/kokkos-execution/impl/completion_signal.hpp
+++ b/kokkos-execution/impl/completion_signal.hpp
@@ -58,29 +58,28 @@ struct RequiresSync {
     }
 };
 
-struct DeferredCompletionReceiverTag : public stdexec::receiver_tag { };
-
-template <typename Rcvr, typename Exec>
-concept deferred_completion_receiver =
-    stdexec::receiver<Rcvr>
-    && std::derived_from<typename std::remove_cvref_t<Rcvr>::receiver_concept, DeferredCompletionReceiverTag>
-    && requires(std::remove_reference_t<Rcvr> rcvr, const Event<Exec>& event) {
-           std::move(rcvr).continues_after();
-           std::move(rcvr).continues_after(event);
-       };
-
-struct SyncPolicy {
-    struct InlineFenceExec { };
-    struct ScheduleWaitEvent { };
-    struct PassThrough { };
-    struct DeferWaitEvent { };
-};
-
 template <typename Policy, Kokkos::ExecutionSpace Exec, stdexec::receiver Rcvr>
 struct CompletionSignal;
 
+struct SyncPolicyTag { };
+
 /**
- * @brief Fence the execution space instance to complete the operation and call @c set_value on the receiver.
+ * @brief Under a sync policy, a terminal completion is propagated: in-flight operations must complete.
+ *
+ * The receiver is invoked after a synchronization through:
+ *   - a fence under @ref InlineFenceExec
+ *   - waiting for an event under @ref ScheduleWaitEvent
+ */
+struct SyncPolicy {
+    struct InlineFenceExec : SyncPolicyTag { };
+    struct ScheduleWaitEvent : SyncPolicyTag { };
+};
+
+template <typename Policy>
+concept sync_policy = std::derived_from<Policy, SyncPolicyTag>;
+
+/**
+ * @brief Fence the execution space instance to complete the operation and then invoke the receiver.
  *
  * Skip the fence if synchronization is not required.
  */
@@ -90,7 +89,7 @@ struct CompletionSignal<SyncPolicy::InlineFenceExec, Exec, Rcvr> {
 
     Rcvr rcvr;
 
-    void propagate(stdexec::set_value_t, const Exec& exec) & noexcept {
+    void propagate(const Exec& exec) & noexcept {
         if (!RequiresSync<Exec, Rcvr>{}(exec, rcvr)) {
             stdexec::set_value(std::move(rcvr));
         } else {
@@ -101,15 +100,6 @@ struct CompletionSignal<SyncPolicy::InlineFenceExec, Exec, Rcvr> {
                 stdexec::set_error(std::move(rcvr), std::current_exception());
             }
         }
-    }
-
-    template <typename Error>
-    void propagate(stdexec::set_error_t, Error&& err) & noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
-    }
-
-    void propagate(stdexec::set_stopped_t) & noexcept {
-        stdexec::set_stopped(std::move(rcvr));
     }
 };
 
@@ -131,7 +121,7 @@ struct ScheduleWaitEventReceiver {
 
 /**
  * @brief Create an event in the execution space instance, and schedule on the delegation scheduler a task that waits
- *        on this event and then calls @c set_value on the receiver.
+ *        on this event and then invoke the receiver.
  *
  * Skip the scheduling of the task if synchronization is not required.
  */
@@ -145,14 +135,10 @@ struct CompletionSignal<SyncPolicy::ScheduleWaitEvent, Exec, Rcvr> {
     >;
 
     Rcvr rcvr;
-    event_storage_t event;
-    OptionalStorage<inner_opstate_t> inner_opstate;
+    event_storage_t event = std::nullopt;
+    OptionalStorage<inner_opstate_t> inner_opstate{};
 
-    constexpr explicit CompletionSignal(Rcvr rcvr_) noexcept(std::is_nothrow_move_constructible_v<Rcvr>)
-        : rcvr(std::move(rcvr_)) {
-    }
-
-    void propagate(stdexec::set_value_t, const Exec& exec) & noexcept {
+    void propagate(const Exec& exec) & noexcept {
         if (!RequiresSync<Exec, Rcvr>{}(exec, rcvr)) {
             stdexec::set_value(std::move(rcvr));
         } else {
@@ -169,37 +155,31 @@ struct CompletionSignal<SyncPolicy::ScheduleWaitEvent, Exec, Rcvr> {
             }
         }
     }
-
-    template <typename Error>
-    void propagate(stdexec::set_error_t, Error&& err) & noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
-    }
-
-    void propagate(stdexec::set_stopped_t) & noexcept {
-        stdexec::set_stopped(std::move(rcvr));
-    }
 };
 
+struct SubmittedPolicyTag { };
+
+/**
+ * Under a submitted policy, an intermediate completion is propagated, signaling
+ * to the receiver that the operation has been submitted to the execution space instance,
+ * but has not necessarily completed yet:
+ *   - @ref OrderOnExec informs that the operation was submitted on the underlying execution space instance
+ *   - @ref DependOnEvent provides an event recorded on the underlying execution space instance after submission
+ */
+struct SubmittedPolicy {
+    struct OrderOnExec : SubmittedPolicyTag { };
+    struct DependOnEvent : SubmittedPolicyTag { };
+};
+
+template <typename Policy>
+concept submitted_policy = std::derived_from<Policy, SubmittedPolicyTag>;
+
 template <Kokkos::ExecutionSpace Exec, stdexec::receiver Rcvr>
-struct CompletionSignal<SyncPolicy::PassThrough, Exec, Rcvr> {
+struct CompletionSignal<SubmittedPolicy::OrderOnExec, Exec, Rcvr> {
     Rcvr rcvr;
 
-    //! @todo Elaborate this overload, which is currently used by the graph customization.
-    void propagate(stdexec::set_value_t) & noexcept {
-        stdexec::set_value(std::move(rcvr));
-    }
-
-    void propagate(stdexec::set_value_t, const Exec&) & noexcept {
-        std::move(rcvr).continues_after();
-    }
-
-    template <typename Error>
-    void propagate(stdexec::set_error_t, Error&& err) & noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
-    }
-
-    void propagate(stdexec::set_stopped_t) & noexcept {
-        stdexec::set_stopped(std::move(rcvr));
+    void propagate(const Exec&) & noexcept {
+        std::move(rcvr).submitted();
     }
 };
 
@@ -210,33 +190,20 @@ struct CompletionSignal<SyncPolicy::PassThrough, Exec, Rcvr> {
  * Skip the creation of the event if synchronization is not required.
  */
 template <Kokkos::ExecutionSpace Exec, stdexec::receiver Rcvr>
-struct CompletionSignal<SyncPolicy::DeferWaitEvent, Exec, Rcvr> {
+struct CompletionSignal<SubmittedPolicy::DependOnEvent, Exec, Rcvr> {
     using event_storage_t = Impl::event_storage_t<Exec>;
 
     Rcvr rcvr;
-    event_storage_t event;
+    event_storage_t event_storage = std::nullopt;
 
-    constexpr explicit CompletionSignal(Rcvr rcvr_) noexcept(std::is_nothrow_move_constructible_v<Rcvr>)
-        : rcvr(std::move(rcvr_)) {
-    }
-
-    void propagate(stdexec::set_value_t, const Exec& exec) & noexcept {
-        if (!RequiresSync<Exec, Rcvr>{}(exec, rcvr)) {
-            std::move(rcvr).continues_after();
+    void propagate(const Exec& exec) & noexcept {
+        if (RequiresSync<Exec, Rcvr>{}(exec, rcvr)) {
+            auto& event = event_storage.emplace();
+            Impl::record(event, exec);
+            std::move(rcvr).submitted(OptionalConstEventRef{event});
         } else {
-            event.emplace();
-            record(*event, exec);
-            std::move(rcvr).continues_after(*event);
+            std::move(rcvr).submitted(OptionalConstEventRef<Exec>{});
         }
-    }
-
-    template <typename Error>
-    void propagate(stdexec::set_error_t, Error&& err) & noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
-    }
-
-    void propagate(stdexec::set_stopped_t) & noexcept {
-        stdexec::set_stopped(std::move(rcvr));
     }
 };
 

--- a/kokkos-execution/impl/event.hpp
+++ b/kokkos-execution/impl/event.hpp
@@ -10,6 +10,8 @@
 #    include "kokkos-utils/callbacks/Manager.hpp"
 #endif
 
+#include "kokkos-execution/impl/optional_ref.hpp"
+
 /**
  * @file
  *
@@ -165,6 +167,10 @@ void wait(const ExecTo& exec, const Event<ExecFrom>& event) {
 
 template <Kokkos::ExecutionSpace Exec>
 using event_storage_t = std::optional<Event<Exec>>;
+
+//! Optionally stores a reference to a @c const @ref Impl::Event.
+template <Kokkos::ExecutionSpace Exec>
+using OptionalConstEventRef = OptionalRef<const Event<Exec>>;
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/optional_ref.hpp
+++ b/kokkos-execution/impl/optional_ref.hpp
@@ -1,0 +1,39 @@
+#ifndef KOKKOS_EXECUTION_IMPL_OPTIONAL_REF_HPP
+#define KOKKOS_EXECUTION_IMPL_OPTIONAL_REF_HPP
+
+#include "Kokkos_Assert.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+/**
+ * @brief A non-owning, nullable reference to a @p T.
+ *
+ * @warning The caller is responsible for ensuring the referenced object outlives the @ref m_ptr handle.
+ */
+template <typename T>
+struct OptionalRef {
+    T* m_ptr = nullptr;
+
+    OptionalRef() = default;
+
+    explicit constexpr OptionalRef(T& value) noexcept
+        : m_ptr(std::addressof(value)) {
+    }
+
+    explicit constexpr OptionalRef(T&&) = delete;
+
+    [[nodiscard]]
+    constexpr bool has_value() const noexcept {
+        return m_ptr != nullptr;
+    }
+
+    [[nodiscard]]
+    constexpr T& get() const noexcept {
+        KOKKOS_EXPECTS(has_value());
+        return *m_ptr;
+    }
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_OPTIONAL_REF_HPP

--- a/kokkos-execution/impl/receiver.hpp
+++ b/kokkos-execution/impl/receiver.hpp
@@ -4,18 +4,19 @@
 #include "kokkos-execution/stdexec.hpp"
 
 #include "kokkos-execution/impl/env.hpp"
+#include "kokkos-execution/impl/submitted.hpp"
 
 namespace Kokkos::Execution::Impl {
 
 //! Receiver for an object @ref parent_op that implements @c complete.
 template <typename ParentOp, typename Env = stdexec::env_of_t<ParentOp>>
 struct Receiver {
-    using receiver_concept = stdexec::receiver_tag;
+    using receiver_concept = SubmittedReceiverTag;
 
     ParentOp* parent_op;
 
     void set_value() && noexcept {
-        parent_op->complete(stdexec::set_value);
+        parent_op->submit();
     }
 
     template <typename Error>
@@ -25,6 +26,10 @@ struct Receiver {
 
     void set_stopped() && noexcept {
         parent_op->complete(stdexec::set_stopped);
+    }
+
+    void submitted() && noexcept {
+        parent_op->submit();
     }
 
     [[nodiscard]]

--- a/kokkos-execution/impl/submitted.hpp
+++ b/kokkos-execution/impl/submitted.hpp
@@ -1,0 +1,41 @@
+#ifndef KOKKOS_EXECUTION_IMPL_SUBMITTED_HPP
+#define KOKKOS_EXECUTION_IMPL_SUBMITTED_HPP
+
+#include "kokkos-execution/stdexec.hpp"
+
+#include "kokkos-execution/impl/completion_signal.hpp"
+#include "kokkos-execution/impl/event.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+struct SubmittedReceiverTag : public stdexec::receiver_tag { };
+
+template <typename Rcvr>
+concept supports_submitted =
+    stdexec::receiver<Rcvr>
+    && std::derived_from<typename std::remove_cvref_t<Rcvr>::receiver_concept, SubmittedReceiverTag>;
+
+template <typename Rcvr>
+concept supports_submitted_order_on = supports_submitted<Rcvr> && requires(Rcvr&& rcvr) {
+    { std::move(rcvr).submitted() } noexcept;
+};
+
+template <typename Rcvr, typename... Execs>
+concept supports_submitted_depend_on = supports_submitted<Rcvr> && (Kokkos::ExecutionSpace<Execs> && ...)
+                                    && sizeof...(Execs) > 0
+                                    && requires(Rcvr&& rcvr, OptionalConstEventRef<Execs>... deps) {
+                                           { std::move(rcvr).submitted(deps...) } noexcept;
+                                       };
+
+struct SubmittedOperationStateTag : public stdexec::operation_state_tag { };
+
+template <typename Op>
+concept signals_submitted =
+    stdexec::operation_state<Op>
+    && std::derived_from<typename std::remove_cvref_t<Op>::operation_state_concept, SubmittedOperationStateTag>
+    && requires { typename std::remove_cvref_t<Op>::completion_signal_policy_t; }
+    && submitted_policy<typename std::remove_cvref_t<Op>::completion_signal_policy_t>;
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_SUBMITTED_HPP

--- a/kokkos-execution/impl/sync_wait.hpp
+++ b/kokkos-execution/impl/sync_wait.hpp
@@ -44,7 +44,7 @@ struct State<std::false_type> {
 //! Receiver for @c stdexec::sync_wait.
 template <Kokkos::ExecutionSpace Exec, typename HasErrorPtr = std::false_type, typename ResultType = std::tuple<>>
 struct Receiver {
-    using receiver_concept = Impl::DeferredCompletionReceiverTag;
+    using receiver_concept = SubmittedReceiverTag;
 
     static constexpr auto label = Impl::dispatch_label<Exec, ": sync_wait">();
 
@@ -71,14 +71,16 @@ struct Receiver {
         runloop_state->loop.finish();
     }
 
-    void continues_after() && noexcept {
+    void submitted() && noexcept {
         state->exec.fence(std::string(label));
         result->emplace();
         runloop_state->loop.finish();
     }
 
-    void continues_after(const Impl::Event<Exec>& event) && noexcept {
-        Impl::wait(event);
+    void submitted(OptionalConstEventRef<Exec> dep) && noexcept {
+        if (dep.has_value()) {
+            Impl::wait(dep.get());
+        }
         result->emplace();
         runloop_state->loop.finish();
     }

--- a/tests/graph/test_bulk.cpp
+++ b/tests/graph/test_bulk.cpp
@@ -226,7 +226,7 @@ TEST_F(BulkTest, bulk_schedule) {
             MATCHER_FOR_GRAPH_ADDNODE(
                 recorded_events.at(0), device_handle, MATCHER_FOR_GRAPH_NODE_OF(recorded_events.at(2))),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), 15);
 }
@@ -289,7 +289,7 @@ TEST_F(BulkTest, bulk_starts_on) {
             MATCHER_FOR_GRAPH_CREATE(device_handle),
             MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), 10);
 }

--- a/tests/graph/test_parallel_for.cpp
+++ b/tests/graph/test_parallel_for.cpp
@@ -158,7 +158,7 @@ TEST_F(ParallelForTest, parallel_for_schedule) {
             MATCHER_FOR_GRAPH_CREATE(device_handle),
             MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), size / 2 * (size - 1));
 }
@@ -189,7 +189,7 @@ TEST_F(ParallelForTest, parallel_for_starts_on) {
             MATCHER_FOR_GRAPH_CREATE(device_handle),
             MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), size / 2 * (size - 1));
 }
@@ -216,7 +216,7 @@ TEST_F(ParallelForTest, parallel_for_schedule_tagged_operator) {
             MATCHER_FOR_GRAPH_CREATE(device_handle),
             MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), 1);
 }

--- a/tests/graph/test_then.cpp
+++ b/tests/graph/test_then.cpp
@@ -212,7 +212,7 @@ TEST_F(ThenTest, then_schedule) {
             MATCHER_FOR_GRAPH_ADDNODE(
                 recorded_events.at(0), device_handle, MATCHER_FOR_GRAPH_NODE_OF(recorded_events.at(1))),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), 7);
 }
@@ -275,7 +275,7 @@ TEST_F(ThenTest, then_starts_on) {
             MATCHER_FOR_GRAPH_CREATE(device_handle),
             MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
             MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
-            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+            MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "after dispatch"))));
 
     ASSERT_EQ(data(), 1);
 }

--- a/tests/impl/test_completion_signal.cpp
+++ b/tests/impl/test_completion_signal.cpp
@@ -79,25 +79,25 @@ consteval bool test_completion_signal_traits() {
         > sizeof(Kokkos::Execution::Impl::SyncWait::Receiver<TEST_EXECUTION_SPACE>)
               + sizeof(Kokkos::Execution::Impl::event_storage_t<TEST_EXECUTION_SPACE>));
 
-    using completion_signal_passthrough_event_t = Kokkos::Execution::Impl::CompletionSignal<
-        Kokkos::Execution::Impl::SyncPolicy::PassThrough,
+    using completion_signal_order_on_exec_t = Kokkos::Execution::Impl::CompletionSignal<
+        Kokkos::Execution::Impl::SubmittedPolicy::OrderOnExec,
         TEST_EXECUTION_SPACE,
         Kokkos::Execution::Impl::SyncWait::Receiver<TEST_EXECUTION_SPACE>
     >;
 
     static_assert(
-        sizeof(completion_signal_passthrough_event_t)
+        sizeof(completion_signal_order_on_exec_t)
         == sizeof(Kokkos::Execution::Impl::SyncWait::Receiver<TEST_EXECUTION_SPACE>));
 
-    using completion_signal_defer_wait_event_t = Kokkos::Execution::Impl::CompletionSignal<
-        Kokkos::Execution::Impl::SyncPolicy::DeferWaitEvent,
+    using completion_signal_depend_on_event_t = Kokkos::Execution::Impl::CompletionSignal<
+        Kokkos::Execution::Impl::SubmittedPolicy::DependOnEvent,
         TEST_EXECUTION_SPACE,
         Tests::Utils::SinkReceiver
     >;
 
     //! The size is larger than the sum of the sizes of the members because of padding.
     static_assert(
-        sizeof(completion_signal_defer_wait_event_t)
+        sizeof(completion_signal_depend_on_event_t)
         > sizeof(Tests::Utils::SinkReceiver) + sizeof(Kokkos::Execution::Impl::event_storage_t<TEST_EXECUTION_SPACE>));
 
     return true;
@@ -111,8 +111,11 @@ TEST_F(CompletionSignalTest, inline_fence_exec_policy) {
             | Kokkos::Execution::parallel_for(pfor_data.label, pfor_data.policy, pfor_data.functor),
         Tests::Utils::SinkReceiver{});
 
-    static_assert(
-        std::same_as<typename decltype(op_state)::sync_policy_t, Kokkos::Execution::Impl::SyncPolicy::InlineFenceExec>);
+    static_assert(std::same_as<
+                  typename decltype(op_state)::completion_signal_policy_t,
+                  Kokkos::Execution::Impl::SyncPolicy::InlineFenceExec
+    >);
+    static_assert(!Kokkos::Execution::Impl::signals_submitted<decltype(op_state)>);
 
     ASSERT_THAT(
         recorder_listener_t::record([&]() { op_state.start(); }),
@@ -121,11 +124,11 @@ TEST_F(CompletionSignalTest, inline_fence_exec_policy) {
     ASSERT_EQ(data(), size / 2 * (size - 1));
 }
 
-template <Kokkos::ExecutionSpace Exec, bool IsDeferredCompletionReceiver>
+template <Kokkos::ExecutionSpace Exec, bool SubmittedOrderOn, bool SubmittedDependOn>
 struct Receiver {
     using receiver_concept = std::conditional_t<
-        IsDeferredCompletionReceiver,
-        Kokkos::Execution::Impl::DeferredCompletionReceiverTag,
+        SubmittedOrderOn || SubmittedDependOn,
+        Kokkos::Execution::Impl::SubmittedReceiverTag,
         stdexec::receiver_tag
     >;
 
@@ -141,15 +144,16 @@ struct Receiver {
         loop->finish();
     }
 
-    void continues_after() && noexcept requires(IsDeferredCompletionReceiver)
+    void submitted() && noexcept requires(SubmittedOrderOn)
     {
         loop->finish();
     }
 
-    void continues_after(const Kokkos::Execution::Impl::Event<Exec>& event) && noexcept
-        requires(IsDeferredCompletionReceiver)
+    void submitted(Kokkos::Execution::Impl::OptionalConstEventRef<Exec> dep) && noexcept requires(SubmittedDependOn)
     {
-        Kokkos::Execution::Impl::wait(event);
+        if (dep.has_value()) {
+            Kokkos::Execution::Impl::wait(dep.get());
+        }
         loop->finish();
     }
 
@@ -174,7 +178,7 @@ TEST_F(CompletionSignalTest, schedule_wait_event_policy) {
     auto op_state = stdexec::connect(
         stdexec::schedule(esc_A.get_scheduler())
             | Kokkos::Execution::parallel_for(pfor_data.label, pfor_data.policy, pfor_data.functor),
-        Receiver<TEST_EXECUTION_SPACE, false>{&esc_B.m_state, &loop});
+        Receiver<TEST_EXECUTION_SPACE, false, false>{&esc_B.m_state, &loop});
 
     const auto recorded_events_before_run = recorder_listener_t::record([&]() { op_state.start(); });
 
@@ -188,8 +192,8 @@ TEST_F(CompletionSignalTest, schedule_wait_event_policy) {
     ASSERT_EQ(data(), size / 2 * (size - 1));
 }
 
-//! @test Check @ref Kokkos::Execution::Impl::CompletionSignal with @ref Kokkos::Execution::Impl::SyncPolicy::PassThrough.
-TEST_F(CompletionSignalTest, passthrough_policy) {
+//! @test Check @ref Kokkos::Execution::Impl::CompletionSignal with @ref Kokkos::Execution::Impl::SubmittedPolicy::OrderOnExec.
+TEST_F(CompletionSignalTest, order_on_exec_policy) {
     Kokkos::Execution::Impl::SyncWait::State<std::true_type> runloop_state;
     std::optional<std::tuple<>> result;
 
@@ -201,8 +205,11 @@ TEST_F(CompletionSignalTest, passthrough_policy) {
             .runloop_state = std::addressof(runloop_state),
             .result = std::addressof(result)});
 
-    static_assert(
-        std::same_as<typename decltype(op_state)::sync_policy_t, Kokkos::Execution::Impl::SyncPolicy::PassThrough>);
+    static_assert(std::same_as<
+                  typename decltype(op_state)::completion_signal_policy_t,
+                  Kokkos::Execution::Impl::SubmittedPolicy::OrderOnExec
+    >);
+    static_assert(Kokkos::Execution::Impl::signals_submitted<decltype(op_state)>);
 
     ASSERT_THAT(
         recorder_listener_t::record([&]() { op_state.start(); }),
@@ -213,8 +220,8 @@ TEST_F(CompletionSignalTest, passthrough_policy) {
     runloop_state.loop.run();
 }
 
-//! @test Check @ref Kokkos::Execution::Impl::CompletionSignal with @ref Kokkos::Execution::Impl::SyncPolicy::DeferWaitEvent.
-TEST_F(CompletionSignalTest, defer_wait_event_policy) {
+//! @test Check @ref Kokkos::Execution::Impl::CompletionSignal with @ref Kokkos::Execution::Impl::SubmittedPolicy::DependOnEvent.
+TEST_F(CompletionSignalTest, depend_on_event_policy) {
     const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
     const context_t esc_A{exec_A}, esc_B{exec_B};
 
@@ -223,14 +230,14 @@ TEST_F(CompletionSignalTest, defer_wait_event_policy) {
     auto op_state = stdexec::connect(
         stdexec::schedule(esc_A.get_scheduler())
             | Kokkos::Execution::parallel_for(pfor_data.label, pfor_data.policy, pfor_data.functor),
-        Receiver<TEST_EXECUTION_SPACE, true>{&esc_B.m_state, &loop});
+        Receiver<TEST_EXECUTION_SPACE, false, true>{&esc_B.m_state, &loop});
 
-    static_assert(Kokkos::Execution::Impl::deferred_completion_receiver<
-                  Receiver<TEST_EXECUTION_SPACE, true>,
-                  TEST_EXECUTION_SPACE
+    static_assert(Kokkos::Execution::Impl::supports_submitted<Receiver<TEST_EXECUTION_SPACE, false, true>>);
+    static_assert(std::same_as<
+                  typename decltype(op_state)::completion_signal_policy_t,
+                  Kokkos::Execution::Impl::SubmittedPolicy::DependOnEvent
     >);
-    static_assert(
-        std::same_as<typename decltype(op_state)::sync_policy_t, Kokkos::Execution::Impl::SyncPolicy::DeferWaitEvent>);
+    static_assert(Kokkos::Execution::Impl::signals_submitted<decltype(op_state)>);
 
     const auto recorded_events = recorder_listener_t::record([&]() { op_state.start(); });
 


### PR DESCRIPTION
This PR proposes to
- rename `continues_after` as `submitted`
- map calling `submitted` on a receiver to calling `submit` on the underlying opstate
- think of `submitted` as a side channel that maps to behavior similar to the `start` function of an operation state, rather than as a completion signal like the `set_value`/`set_error`/`set_stopped` of a receiver

The idea of the name `submitted` is that the predecessor notifies the successor that it has submitted its work. The name is also nice for graph, because as we go through the receivers, we kind of let the next one know that the graph has been submitted.

In CCCL, the start function starts the predecessor operation state and then launches its own work. With this approach, the successor work can already be launched even before the predecessor calls set_value. So we get the overlap benefit.

https://github.com/NVIDIA/cccl/blob/5d79bc23cf9e116b5a9139e5bb85d6d8464a6836/cudax/include/cuda/experimental/__execution/stream/schedule_from.cuh#L119-L138

However, this CCCL approach seems quite brittle because it's not clear that after returning from starting the predecessor opstate, which may itself lead to a sequence of nested calls,  the thread returning really implies that the predecessor's work has been launched. E.g., this approach may break in a case in which the predecessor delegates set_value to a delegation scheduler.

So rather than enqueueing work in `start` immediately after starting the predecessor operation state, we enqueue the work in a separate`submit` function that the predecessor may trigger after it has submitted its work.

One thought is that as part of such a `submit`, there could in principle be a functionality that would call `set_value` on the predecessor receiver on completion of the predecessor work. In that case, `set_value` would be a no-op. It may not make sense to implement that, but just making sure that this would conceptually be possible may be a way to ensure our design is compliant with the standard. I.e. `submitted` is not a completion function. The completion functions remain `set_value`/`set_error`/`set_stopped`. It's just that we don't call `set_value` because it's a no-op.

Proposed next steps:
- try to see if we can avoid opstatebase in graph
- work on the `OrderOn` and `DependOn` objects with functionalities

