### PR TITLE
ExecutionSpaceImpl: rename `execute` as `submit`

### DIFF
--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -19,7 +19,7 @@ template <typename Clsr>
 concept Closure = requires(const Clsr& clsr) {
     typename Clsr::execution_space;
 
-    { clsr.execute() } -> std::same_as<void>;
+    { clsr.submit() } -> std::same_as<void>;
 
     { clsr.get_policy() };
     requires Kokkos::ExecutionPolicy<std::remove_cvref_t<decltype(clsr.get_policy())>>;
@@ -68,7 +68,7 @@ struct OpStateBase {
 
     void complete(stdexec::set_value_t) noexcept {
         try {
-            stdexec::__apply([](auto&... clsr) { (clsr.execute(), ...); }, clsrs);
+            stdexec::__apply([](auto&... clsr) { (clsr.submit(), ...); }, clsrs);
         } catch (...) {
             this->complete(stdexec::set_error, std::current_exception());
             return;

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -20,7 +20,7 @@ struct ParallelForClosure {
 
     Kokkos::Execution::Impl::ParallelForData<Label, Functor, policy_t> data;
 
-    void execute() const & {
+    void submit() const & {
         if constexpr (std::convertible_to<Label, std::string>) {
             Kokkos::parallel_for(data.label, data.policy, data.functor);
         } else {


### PR DESCRIPTION
To make it more clear that we're "enqueueing" rather than eagerly executing.