### PR TITLE
Tests: trailing return types for check utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ target_sources(
             kokkos-execution/impl/schedulers.hpp
             kokkos-execution/impl/state.hpp
             kokkos-execution/impl/sync_wait.hpp
+            kokkos-execution/impl/type_traits.hpp
             kokkos-execution/utils/ignore_warnings.hpp
 )
 

--- a/kokkos-execution/execution_space/scoped_region.hpp
+++ b/kokkos-execution/execution_space/scoped_region.hpp
@@ -13,6 +13,7 @@
 #include "kokkos-execution/impl/completion_signatures.hpp"
 #include "kokkos-execution/impl/env.hpp"
 #include "kokkos-execution/impl/sender_introspection.hpp"
+#include "kokkos-execution/impl/type_traits.hpp"
 
 /**
  * @file
@@ -80,17 +81,30 @@ struct RegionSender {
     template <typename Rcvr>
     using rcvr_t = RegionReceiver<kind, schd_t<Rcvr>, Rcvr>;
 
-    template <stdexec::receiver Rcvr>
-    stdexec::operation_state auto connect(Rcvr rcvr) && noexcept(
-        std::is_nothrow_constructible_v<rcvr_t<Rcvr>, std::string&&, schd_t<Rcvr>&&, Rcvr&&>
-        && stdexec::__nothrow_connectable<Sndr&&, rcvr_t<Rcvr>>) {
-        auto schd =
-            stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), stdexec::get_env(rcvr));
+    template <stdexec::__decays_to<RegionSender> Self, stdexec::receiver Rcvr>
+    [[nodiscard]]
+    constexpr STDEXEC_EXPLICIT_THIS_BEGIN(
+        auto connect)(this Self&& self, Rcvr rcvr) // NOLINT(cppcoreguidelines-missing-std-forward)
+        noexcept(
+            std::is_nothrow_constructible_v<
+                rcvr_t<Rcvr>,
+                KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, name),
+                schd_t<Rcvr>&&,
+                Rcvr&&
+            >
+            && stdexec::__nothrow_connectable<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), rcvr_t<Rcvr>&&>)
+            -> stdexec::connect_result_t<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), rcvr_t<Rcvr>&&> {
+        auto schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(
+            stdexec::get_env(self.sndr), stdexec::get_env(rcvr));
 
         return stdexec::connect(
-            std::forward<Sndr>(sndr),
-            rcvr_t<Rcvr>{.name = std::move(name), .schd = std::move(schd), .rcvr = std::move(rcvr)});
+            KOKKOS_EXECUTION_IMPL_FORWARD_THIS(Self, self).sndr,
+            rcvr_t<Rcvr>{
+                .name = KOKKOS_EXECUTION_IMPL_FORWARD_THIS(Self, self).name,
+                .schd = std::move(schd),
+                .rcvr = std::move(rcvr)});
     }
+    STDEXEC_EXPLICIT_THIS_END(connect)
 
     std::string name{};
     Sndr sndr;

--- a/kokkos-execution/impl/type_traits.hpp
+++ b/kokkos-execution/impl/type_traits.hpp
@@ -1,0 +1,28 @@
+#ifndef KOKKOS_EXECUTION_IMPL_TYPE_TRAITS_HPP
+#define KOKKOS_EXECUTION_IMPL_TYPE_TRAITS_HPP
+
+#include <type_traits>
+#include <utility>
+
+#include "Kokkos_Macros.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+/**
+ * @brief Yields the type of member @p _member_ as accessed from expression @p _Self_,
+ *        preserving the @c cv and @c ref qualifiers of @p _Self_.
+ *
+ * Useful for propagating value category from a deducing-this parameter to one of its members.
+ */ // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(_Self_, _member_) decltype((std::declval<_Self_>()._member_))
+
+/**
+ * @brief Equivalent to @c std::forward<_Self_>(_self_).
+ *
+ * Avoids @c clang-tidy @c bugprone-use-after-move heuristic issues.
+ */ // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define KOKKOS_EXECUTION_IMPL_FORWARD_THIS(_Self_, _self_)     static_cast<_Self_&&>(_self_)
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_TYPE_TRAITS_HPP

--- a/tests/utils/check_rcvr_env.hpp
+++ b/tests/utils/check_rcvr_env.hpp
@@ -5,6 +5,7 @@
 
 #include "kokkos-execution/impl/attributes.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
+#include "kokkos-execution/impl/type_traits.hpp"
 
 namespace Tests::Utils {
 
@@ -16,17 +17,16 @@ struct CheckRcvrEnvSender {
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvSender)
 
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) && noexcept(stdexec::__nothrow_connectable<Sndr&&, Rcvr&&>) {
+    template <stdexec::__decays_to<CheckRcvrEnvSender> Self, stdexec::receiver Rcvr>
+    [[nodiscard]]
+    constexpr STDEXEC_EXPLICIT_THIS_BEGIN(
+        auto connect)(this Self&& self, Rcvr rcvr) // NOLINT(cppcoreguidelines-missing-std-forward)
+        noexcept(stdexec::__nothrow_connectable<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&>)
+            -> stdexec::connect_result_t<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&> {
         static_assert(std::same_as<ExpectedEnv, stdexec::env_of_t<Rcvr>>);
-        return stdexec::connect(std::forward<Sndr>(sndr), std::move(rcvr));
+        return stdexec::connect(std::forward<Self>(self).sndr, std::move(rcvr));
     }
-
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) const & noexcept(stdexec::__nothrow_connectable<Sndr const &, Rcvr&&>) {
-        static_assert(std::same_as<ExpectedEnv, stdexec::env_of_t<Rcvr>>);
-        return stdexec::connect(sndr, std::move(rcvr));
-    }
+    STDEXEC_EXPLICIT_THIS_END(connect)
 
     KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
 };

--- a/tests/utils/check_rcvr_env_queryable_with.hpp
+++ b/tests/utils/check_rcvr_env_queryable_with.hpp
@@ -6,6 +6,7 @@
 #include "kokkos-execution/impl/attributes.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
 #include "kokkos-execution/impl/env.hpp"
+#include "kokkos-execution/impl/type_traits.hpp"
 
 #include "tests/utils/stdexec.hpp"
 
@@ -42,17 +43,16 @@ struct CheckRcvrEnvQueryableWithSender {
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvQueryableWithSender)
 
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) && noexcept(stdexec::__nothrow_connectable<Sndr&&, Rcvr&&>) {
+    template <stdexec::__decays_to<CheckRcvrEnvQueryableWithSender> Self, stdexec::receiver Rcvr>
+    [[nodiscard]]
+    constexpr STDEXEC_EXPLICIT_THIS_BEGIN(
+        auto connect)(this Self&& self, Rcvr rcvr) // NOLINT(cppcoreguidelines-missing-std-forward)
+        noexcept(stdexec::__nothrow_connectable<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&>)
+            -> stdexec::connect_result_t<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&> {
         static_assert(check_rcvr_env<Rcvr>());
-        return stdexec::connect(std::forward<Sndr>(sndr), std::move(rcvr));
+        return stdexec::connect(std::forward<Self>(self).sndr, std::move(rcvr));
     }
-
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) const & noexcept(stdexec::__nothrow_connectable<const Sndr&, Rcvr&&>) {
-        static_assert(check_rcvr_env<Rcvr>());
-        return stdexec::connect(sndr, std::move(rcvr));
-    }
+    STDEXEC_EXPLICIT_THIS_END(connect)
 
     template <stdexec::receiver Rcvr>
     static consteval bool check_rcvr_env() {

--- a/tests/utils/check_scheduler_type.hpp
+++ b/tests/utils/check_scheduler_type.hpp
@@ -7,6 +7,7 @@
 #include "kokkos-execution/impl/completion_signatures.hpp"
 #include "kokkos-execution/impl/env.hpp"
 #include "kokkos-execution/impl/sender_introspection.hpp"
+#include "kokkos-execution/impl/type_traits.hpp"
 
 #include "tests/utils/stdexec.hpp"
 
@@ -43,17 +44,16 @@ struct CheckSchedulerTypeSender {
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckSchedulerTypeSender)
 
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) && noexcept(stdexec::__nothrow_connectable<Sndr&&, Rcvr&&>) {
+    template <stdexec::__decays_to<CheckSchedulerTypeSender> Self, stdexec::receiver Rcvr>
+    [[nodiscard]]
+    constexpr STDEXEC_EXPLICIT_THIS_BEGIN(
+        auto connect)(this Self&& self, Rcvr rcvr) // NOLINT(cppcoreguidelines-missing-std-forward)
+        noexcept(stdexec::__nothrow_connectable<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&>)
+            -> stdexec::connect_result_t<KOKKOS_EXECUTION_IMPL_MEMBER_CVREF_T(Self, sndr), Rcvr&&> {
         static_assert(check_scheduler_type<Rcvr>());
-        return stdexec::connect(std::forward<Sndr>(sndr), std::move(rcvr));
+        return stdexec::connect(std::forward<Self>(self).sndr, std::move(rcvr));
     }
-
-    template <stdexec::receiver Rcvr>
-    constexpr auto connect(Rcvr rcvr) const & noexcept(stdexec::__nothrow_connectable<const Sndr&, Rcvr&&>) {
-        static_assert(check_scheduler_type<Rcvr>());
-        return stdexec::connect(sndr, std::move(rcvr));
-    }
+    STDEXEC_EXPLICIT_THIS_END(connect)
 
     template <stdexec::receiver Rcvr>
     static consteval bool check_scheduler_type() {

--- a/tests/utils/test_check_rcvr_env_queryable_with.cpp
+++ b/tests/utils/test_check_rcvr_env_queryable_with.cpp
@@ -21,16 +21,24 @@ constexpr struct PropA : public ::stdexec::__query<PropA> {
 struct PropB : public ::stdexec::__query<PropB> { };
 
 /**
- * @test Write @ref PropA in the environment with @c stdexec::write_env and check that @ref Tests::Utils::check_rcvr_env_queryable_with
- *       indicates that the environment is queryable with @ref PropA and
- *       @ref Tests::Utils::check_rcvr_env_not_queryable_with indicates that the environment is not queryable with @ref PropB.
+ * Write @ref PropA in the environment with @c stdexec::write_env and check that @ref Tests::Utils::check_rcvr_env_queryable_with
+ * indicates that the environment is queryable with @ref PropA and
+ * @ref Tests::Utils::check_rcvr_env_not_queryable_with indicates that the environment is not queryable with @ref PropB.
  */
-TEST(check_rcvr_env_queryable_with, and_not) {
-    auto sndr = stdexec::just() | Tests::Utils::check_rcvr_env_queryable_with<PropA>()
-              | Tests::Utils::check_rcvr_env_not_queryable_with<PropB>()
-              | stdexec::write_env(stdexec::prop{prop_a, 42.});
+consteval auto get_sndr() {
+    return stdexec::just() | Tests::Utils::check_rcvr_env_queryable_with<PropA>()
+         | Tests::Utils::check_rcvr_env_not_queryable_with<PropB>() | stdexec::write_env(stdexec::prop{prop_a, 42.});
+}
 
-    stdexec::sync_wait(std::move(sndr)); // NOLINT(performance-move-const-arg)
+//! @test Check @ref Tests::Utils::check_rcvr_env_queryable_with and @ref Tests::Utils::check_rcvr_env_not_queryable_with with an rvalue sender.
+TEST(check_rcvr_env_queryable_with, and_not_rvalue) {
+    stdexec::sync_wait(get_sndr());
+}
+
+//! @test Check @ref Tests::Utils::check_rcvr_env_queryable_with and @ref Tests::Utils::check_rcvr_env_not_queryable_with with an lvalue sender.
+TEST(check_rcvr_env_queryable_with, and_not_lvalue) {
+    auto sndr = get_sndr();
+    stdexec::sync_wait(sndr);
 }
 
 } // namespace Tests


### PR DESCRIPTION
Extracted from
- #204 

It appears we cannot add trailing return types to a pair of `connect &&` and `connect const&` overloads because that requires that we support the pair everywhere.

Note that the PR proposes to use `std::forward<Self>(self).sndr` instead of `stdexec::__forward_like<Self>(self.sndr)`. The difference is that in the case that the sender is held as a reference, the `connect &&` overload will forward the sender as a reference with the proposed version, while it would forward it as an rvalue reference with the forward like version.

```
struct MyStruct {
    int my_val = -1;
    int& my_ref = my_val; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
};

// connect && overload
static_assert(std::same_as<decltype((std::declval<MyStruct>().my_val)), int&&>);
static_assert(std::same_as<decltype((std::declval<MyStruct>().my_ref)), int&>);

static_assert(std::same_as<stdexec::__copy_cvref_t<MyStruct, int>, int>);
static_assert(std::same_as<stdexec::__copy_cvref_t<MyStruct, int&>, int&>);

static_assert(std::same_as<decltype(stdexec::__forward_like<MyStruct>(MyStruct{}.my_val)), int&&>);
static_assert(std::same_as<decltype(stdexec::__forward_like<MyStruct>(MyStruct{}.my_ref)), int&&>); // -> instead of int& as intended (connect will eat the inner sender that it holds a reference to)

// connect const & overload
static_assert(std::same_as<decltype((std::declval<const MyStruct&>().my_val)), const int&>);
static_assert(std::same_as<decltype((std::declval<const MyStruct&>().my_ref)), int&>);

static_assert(std::same_as<stdexec::__copy_cvref_t<const MyStruct&, int>, const int&>);
static_assert(std::same_as<stdexec::__copy_cvref_t<const MyStruct&, int&>, int&>);

// double parentheses are needed
static_assert(std::same_as<decltype(std::declval<MyStruct>().my_val), int>); // -> instead of int&& as intended
```  