### PR TITLE
cicd: clang 22 debug

### DIFF
--- a/.github/workflows/build.images.yml
+++ b/.github/workflows/build.images.yml
@@ -133,12 +133,8 @@ jobs:
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, base_image: ubuntu:24.04, platforms: linux/amd64, cmake_build_type: Debug}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, base_image: ubuntu:24.04, platforms: linux/amd64, cmake_build_type: Release}
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 15}, base_image: ubuntu:26.04, platforms: linux/amd64, python_version: 3.14}
-          - kokkos_backends: [OpenMP]
-            compiler:
-              family: clang
-              version: 22
-            base_image     : ubuntu:24.04
-            platforms      : linux/amd64
+          - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, base_image: ubuntu:24.04, platforms: linux/amd64, cmake_build_type: Debug}
+          - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, base_image: ubuntu:24.04, platforms: linux/amd64, cmake_build_type: Release}
           - kokkos_backends: [HPX]
             compiler:
               family: gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           - {kokkos_backends: [OpenMP], compiler: {family: gnu, version: 14}, cxxflags: "-fsanitize=thread -Wno-error=tsan", env: {OMP_NUM_THREADS: 1}}
           - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "20", extra_type_checking: true}
           - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "23"}
+          - {kokkos_backends: [OpenMP], compiler: {family: clang, version: 22}, cxxstd: "20", cmake_build_type: Debug}
           - kokkos_backends: [HPX]
             compiler:
               family: gnu


### PR DESCRIPTION
This PR adds a debug build with `clang`.

Note: I think we only had one debug build, with `gcc`.