### PR TITLE
impl(env): `KOKKOS_EXECUTION_GET_ENV` macro

### DIFF
--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -87,10 +87,7 @@ struct OpStateBase {
         return Impl::ExecutionSpaceRef<execution_space>{stdexec::__get<0>(clsrs).get_policy().space()};
     }
 
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept -> stdexec::env_of_t<Rcvr> {
-        return stdexec::get_env(this->completion_signal.rcvr);
-    }
+    KOKKOS_EXECUTION_GET_ENV(Rcvr, this->completion_signal.rcvr)
 };
 
 template <stdexec::sender Sndr, stdexec::receiver Rcvr, Closure... Clsrs>

--- a/kokkos-execution/graph/operation_state.hpp
+++ b/kokkos-execution/graph/operation_state.hpp
@@ -195,10 +195,7 @@ struct OpState
         stdexec::start(inner_opstate);
     }
 
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept -> stdexec::env_of_t<Rcvr> {
-        return stdexec::get_env(this->completion_signal.rcvr);
-    }
+    KOKKOS_EXECUTION_GET_ENV(Rcvr, this->completion_signal.rcvr)
 };
 
 template <typename Sndr, typename Rcvr, typename... Clsrs>

--- a/kokkos-execution/graph/when_all.hpp
+++ b/kokkos-execution/graph/when_all.hpp
@@ -152,10 +152,7 @@ struct WhenAllOpState
         this->completion_signal.propagate(state.get_device_handle().m_exec);
     }
 
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept -> stdexec::env_of_t<Rcvr> {
-        return stdexec::get_env(this->completion_signal.rcvr);
-    }
+    KOKKOS_EXECUTION_GET_ENV(Rcvr, this->completion_signal.rcvr)
 };
 
 //! Sender for @c stdexec::when_all.

--- a/kokkos-execution/impl/env.hpp
+++ b/kokkos-execution/impl/env.hpp
@@ -10,4 +10,11 @@
         return ::stdexec::__fwd_env(::stdexec::get_env(_obj_));                                                        \
     }
 
+//! Retrieve the environment of @p _obj_. // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define KOKKOS_EXECUTION_GET_ENV(_type_, _obj_)                                                                        \
+    [[nodiscard]]                                                                                                      \
+    constexpr auto get_env() const noexcept -> stdexec::env_of_t<_type_> {                                             \
+        return stdexec::get_env(_obj_);                                                                                \
+    }
+
 #endif // KOKKOS_EXECUTION_IMPL_ENV_HPP


### PR DESCRIPTION
This PR introduces the `KOKKOS_EXECUTION_GET_ENV` macro when we want to return the environment without forwarding.