### PR TITLE
ExecutionSpaceImpl: `schedule_from` and `continues_on`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,12 +118,16 @@ target_sources(
             kokkos-execution/impl/bulk.hpp
             kokkos-execution/impl/completion_signal.hpp
             kokkos-execution/impl/completion_signatures.hpp
+            kokkos-execution/impl/Cuda/dependency.hpp
             kokkos-execution/impl/Cuda/event.hpp
+            kokkos-execution/impl/dependency.hpp
             kokkos-execution/impl/dispatch_label.hpp
             kokkos-execution/impl/domain.hpp
+            kokkos-execution/impl/empty.hpp
             kokkos-execution/impl/env.hpp
             kokkos-execution/impl/get_exec.hpp
             kokkos-execution/impl/event.hpp
+            kokkos-execution/impl/HIP/dependency.hpp
             kokkos-execution/impl/HIP/event.hpp
             kokkos-execution/impl/HPX/event.hpp
             kokkos-execution/impl/immovable.hpp
@@ -133,6 +137,7 @@ target_sources(
             kokkos-execution/impl/receiver.hpp
             kokkos-execution/impl/sender_concepts.hpp
             kokkos-execution/impl/sender_introspection.hpp
+            kokkos-execution/impl/SYCL/dependency.hpp
             kokkos-execution/impl/SYCL/event.hpp
             kokkos-execution/impl/schedulers.hpp
             kokkos-execution/impl/state.hpp

--- a/kokkos-execution/execution_space/continues_on.hpp
+++ b/kokkos-execution/execution_space/continues_on.hpp
@@ -4,34 +4,131 @@
 #include "kokkos-execution/execution_space/env.hpp"
 #include "kokkos-execution/impl/attributes.hpp"
 #include "kokkos-execution/impl/completion_signatures.hpp"
+#include "kokkos-execution/impl/dependency.hpp"
+#include "kokkos-execution/impl/empty.hpp"
+#include "kokkos-execution/impl/receiver.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
 //! Receiver for @c continues_on.
-template <typename ExecEnvPolicy, stdexec::scheduler Schd, stdexec::receiver Rcvr>
-struct ContinuesOnReceiver {
-    using receiver_concept = stdexec::receiver_tag;
+template <typename ParentOp, typename Env = stdexec::env_of_t<ParentOp>>
+struct ContinuesOnReceiver : public Impl::Receiver<ParentOp, Env> {
+    using exec_env_policy_t = typename ParentOp::exec_env_policy_t;
 
-    Schd schd;
+    [[nodiscard]]
+    constexpr auto
+        get_env() const noexcept -> join_env_with_exec_t<exec_env_policy_t, Env, typename ParentOp::execution_space> {
+        return join_env_with_exec<exec_env_policy_t>(
+            stdexec::get_env(*this->parent_op), Impl::get_exec(*this->parent_op).get());
+    }
+};
+
+template <typename InnerOp, typename ExecTo, typename Rcvr>
+concept continues_on_signals_submitted = Impl::signals_submitted<InnerOp>
+                                      && std::same_as<ExecTo, Impl::exec_of_t<InnerOp>>
+                                      && Impl::supports_submitted_order_on<Rcvr>;
+
+template <typename InnerOp, typename ExecTo, typename Rcvr>
+struct DependencyFor {
+    using type = Impl::Empty;
+};
+
+template <typename InnerOp, typename ExecTo, typename Rcvr>
+requires Impl::signals_submitted<InnerOp>
+struct DependencyFor<InnerOp, ExecTo, Rcvr> {
+    using type = Impl::Dependency<ExecTo, Impl::exec_of_t<InnerOp>>;
+};
+
+template <typename InnerOp, typename ExecTo, typename Rcvr>
+using dependency_for_t = typename DependencyFor<InnerOp, ExecTo, Rcvr>::type;
+
+template <stdexec::scheduler Schd, stdexec::receiver Rcvr>
+struct ContinuesOnOpStateBase {
+    using execution_space = typename Schd::execution_space;
+
     Rcvr rcvr;
+    Schd schd;
 
-    void set_value() && noexcept {
-        stdexec::set_value(std::move(rcvr));
+    [[nodiscard]]
+    constexpr auto query(Impl::get_exec_t) const noexcept -> Impl::ExecutionSpaceRef<execution_space> {
+        return Impl::ExecutionSpaceRef<execution_space>{schd.state->exec};
+    }
+
+    KOKKOS_EXECUTION_GET_ENV(Rcvr, this->rcvr)
+};
+
+template <stdexec::scheduler Schd, stdexec::sender Sndr, stdexec::receiver Rcvr>
+struct ContinuesOnOpState
+    : public Impl::Immovable
+    , public ContinuesOnOpStateBase<Schd, Rcvr> {
+    using operation_state_concept = Impl::SubmittedOperationStateTag;
+
+    using base_t = ContinuesOnOpStateBase<Schd, Rcvr>;
+    using execution_space = typename base_t::execution_space;
+
+    using exec_env_policy_t = std::conditional_t<
+        std::same_as<stdexec::__completion_domain_of_t<stdexec::set_value_t, Sndr, stdexec::env_of_t<Rcvr>>, Domain>,
+        WithExecEnvPolicy,
+        WithoutExecEnvPolicy
+    >;
+
+    using rcvr_t = ContinuesOnReceiver<ContinuesOnOpState, stdexec::env_of_t<Rcvr>>;
+
+    using inner_opstate_t = stdexec::connect_result_t<Sndr, rcvr_t>;
+
+    using completion_signal_policy_t = std::conditional_t<
+        continues_on_signals_submitted<inner_opstate_t, execution_space, Rcvr>,
+        Impl::SubmittedPolicy::OrderOnExec,
+        Impl::SyncPolicy::InlineFenceExec
+    >;
+
+    using dependency_t = dependency_for_t<inner_opstate_t, execution_space, Rcvr>;
+
+    [[no_unique_address]]
+    std::optional<dependency_t> dependency{};
+    inner_opstate_t inner_opstate;
+
+    constexpr explicit ContinuesOnOpState(
+        Sndr&& sndr, // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+        Schd&& schd, // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+        Rcvr rcvr)
+        noexcept(
+            std::is_nothrow_constructible_v<base_t, Rcvr&&, Schd&&> && stdexec::__nothrow_connectable<Sndr&&, rcvr_t>)
+        : base_t(std::move(rcvr), std::forward<Schd>(schd))
+        , inner_opstate(stdexec::connect(std::forward<Sndr>(sndr), rcvr_t{this})) {
+    }
+
+    void complete(stdexec::set_value_t) noexcept {
+        stdexec::set_value(std::move(this->rcvr));
     }
 
     template <typename Error>
-    void set_error(Error&& err) && noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
+    void complete(stdexec::set_error_t, Error&& error) noexcept {
+        stdexec::set_error(std::move(this->rcvr), std::forward<Error>(error));
     }
 
-    void set_stopped() && noexcept {
-        stdexec::set_stopped(std::move(rcvr));
+    void complete(stdexec::set_stopped_t) noexcept {
+        stdexec::set_stopped(std::move(this->rcvr));
     }
 
-    [[nodiscard]]
-    constexpr auto get_env() const noexcept
-        -> join_env_with_exec_t<ExecEnvPolicy, stdexec::env_of_t<Rcvr>, typename Schd::execution_space> {
-        return join_env_with_exec<ExecEnvPolicy>(stdexec::get_env(rcvr), schd.state->exec);
+    void submit() noexcept {
+        const auto& exec_from = Impl::get_exec(this->inner_opstate).get();
+        const auto& exec_to = Impl::get_exec(*this).get();
+        this->dependency.emplace(exec_to, exec_from);
+        try {
+            if constexpr (std::same_as<completion_signal_policy_t, Impl::SubmittedPolicy::OrderOnExec>) {
+                std::move(this->rcvr).submitted();
+            } else {
+                static_assert(std::same_as<completion_signal_policy_t, Impl::SyncPolicy::InlineFenceExec>);
+                stdexec::set_value(std::move(this->rcvr));
+            }
+        } catch (...) {
+            stdexec::set_error(std::move(this->rcvr), std::current_exception());
+        }
+    }
+
+    void start() & noexcept {
+        stdexec::start(inner_opstate);
     }
 };
 
@@ -42,25 +139,12 @@ struct ContinuesOnSender {
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender)
 
-    template <typename Rcvr>
-    using exec_env_policy_t = std::conditional_t<
-        std::same_as<
-            stdexec::__completion_domain_of_t<stdexec::set_value_t, Sndr, stdexec::__fwd_env_t<stdexec::env_of_t<Rcvr>>>,
-            Domain
-        >,
-        WithExecEnvPolicy,
-        WithoutExecEnvPolicy
-    >;
-
-    template <typename Rcvr>
-    using rcvr_t = ContinuesOnReceiver<exec_env_policy_t<Rcvr>, Schd, Rcvr>;
-
     template <stdexec::receiver Rcvr>
     constexpr auto connect(Rcvr rcvr) && noexcept(
-        std::is_nothrow_constructible_v<rcvr_t<Rcvr>, Schd&&, Rcvr&&>
-        && stdexec::__nothrow_connectable<Sndr&&, rcvr_t<Rcvr>>) -> stdexec::connect_result_t<Sndr, rcvr_t<Rcvr>> {
-        return stdexec::connect(
-            std::forward<Sndr>(sndr), rcvr_t<Rcvr>{.schd = std::forward<Schd>(schd), .rcvr = std::move(rcvr)});
+        std::is_nothrow_constructible_v<ContinuesOnOpState<Schd, Sndr, Rcvr>, Sndr&&, Schd&&, Rcvr&&>)
+        -> ContinuesOnOpState<Schd, Sndr, Rcvr> {
+        return ContinuesOnOpState<Schd, Sndr, Rcvr>{
+            std::forward<Sndr>(sndr), std::forward<Schd>(schd), std::move(rcvr)};
     }
 
     KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)

--- a/kokkos-execution/execution_space/env.hpp
+++ b/kokkos-execution/execution_space/env.hpp
@@ -37,7 +37,7 @@ using join_env_with_exec_t = decltype(join_env_with_exec<ExecEnvPolicy>(std::dec
  * @note This is not the same intent as using a forwarding query.
  */
 template <typename ExecEnvPolicy, typename Env>
-constexpr auto extend_env(Env&& env) noexcept {
+constexpr auto extend_env_with_exec(Env&& env) noexcept {
     if constexpr (std::same_as<ExecEnvPolicy, WithExecEnvPolicy>) {
         auto ref = Impl::get_exec(env);
         return stdexec::__env::__join(
@@ -48,11 +48,11 @@ constexpr auto extend_env(Env&& env) noexcept {
 }
 
 template <typename ExecEnvPolicy, typename Env>
-using extend_env_t = decltype(extend_env<ExecEnvPolicy>(std::declval<Env>()));
+using extend_env_with_exec_t = decltype(extend_env_with_exec<ExecEnvPolicy>(std::declval<Env>()));
 
 //! If @p Env is queryable with @ref Impl::get_exec_t, use @ref WithExecEnvPolicy.
 template <typename Env>
-using exec_env_policy_t =
+using extend_env_with_exec_policy_t =
     std::conditional_t<stdexec::__queryable_with<Env, Impl::get_exec_t>, WithExecEnvPolicy, WithoutExecEnvPolicy>;
 
 } // namespace Kokkos::Execution::ExecutionSpaceImpl

--- a/kokkos-execution/execution_space/execution_space_fwd.hpp
+++ b/kokkos-execution/execution_space/execution_space_fwd.hpp
@@ -16,9 +16,6 @@ struct Domain;
 template <Kokkos::ExecutionSpace Exec>
 struct Scheduler;
 
-template <typename...>
-struct ScheduleFromReceiver;
-
 } // namespace Kokkos::Execution::ExecutionSpaceImpl
 
 #endif // KOKKOS_EXECUTION_EXECUTION_SPACE_EXECUTION_SPACE_FWD_HPP

--- a/kokkos-execution/execution_space/operation_state.hpp
+++ b/kokkos-execution/execution_space/operation_state.hpp
@@ -62,6 +62,10 @@ struct OpStateBase {
         , clsrs(std::move(clsr_), std::move(clsrs_)...) {
     }
 
+    void complete(stdexec::set_value_t) noexcept {
+        this->submit();
+    }
+
     template <typename Error>
     void complete(stdexec::set_error_t, Error&& error) noexcept {
         stdexec::set_error(std::move(completion_signal.rcvr), std::forward<Error>(error));

--- a/kokkos-execution/execution_space/schedule_from.hpp
+++ b/kokkos-execution/execution_space/schedule_from.hpp
@@ -10,126 +10,121 @@
 #include "kokkos-execution/impl/completion_signatures.hpp"
 #include "kokkos-execution/impl/env.hpp"
 #include "kokkos-execution/impl/get_exec.hpp"
+#include "kokkos-execution/impl/receiver.hpp"
 #include "kokkos-execution/impl/sender_introspection.hpp"
+#include "kokkos-execution/impl/submitted.hpp"
 
 namespace Kokkos::Execution::ExecutionSpaceImpl {
 
-struct WithDelegatedSyncPolicy { };
-struct WithoutDelegatedSyncPolicy { };
+template <typename ParentOp, typename Env = stdexec::env_of_t<ParentOp>>
+struct ScheduleFromReceiver : public Impl::Receiver<ParentOp, Env> {
+    using exec_env_policy_t = typename ParentOp::exec_env_policy_t;
 
-//! Receiver for @c schedule_from.
-template <stdexec::scheduler Schd, stdexec::receiver Rcvr>
-struct ScheduleFromReceiver<WithDelegatedSyncPolicy, WithoutExecEnvPolicy, Schd, Rcvr> {
-    using receiver_concept = Impl::SubmittedReceiverTag;
-
-    Schd schd;
-    Rcvr rcvr;
-
-    void set_value() && noexcept {
-        stdexec::set_value(std::move(rcvr));
+    [[nodiscard]]
+    constexpr auto get_env() const noexcept -> extend_env_with_exec_t<exec_env_policy_t, Env> {
+        return extend_env_with_exec<exec_env_policy_t>(stdexec::get_env(*this->parent_op));
     }
-
-    void submitted() && noexcept {
-        /// If the downstream receiver environment is queryable for @ref Kokkos::Execution::Impl::get_exec
-        /// and it shares the same execution space instance, skip the fence.
-        const bool requires_synchronization = [&]() {
-            if constexpr (stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>) {
-                if constexpr (
-                    std::same_as<
-                        typename std::remove_cvref_t<
-                            stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, Impl::get_exec_t>
-                        >::execution_space,
-                        typename Schd::execution_space
-                    >) {
-                    return Impl::get_exec(stdexec::get_env(rcvr)).get() != schd.state->exec;
-                }
-            }
-            return true;
-        }();
-        if (requires_synchronization) {
-            schd.state->exec.fence(
-                std::format("{}: schedule_from", Kokkos::Impl::TypeInfo<typename Schd::execution_space>::name()));
-        }
-        stdexec::set_value(std::move(rcvr));
-    }
-
-    template <typename Error>
-    void set_error(Error&& err) && noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
-    }
-
-    void set_stopped() && noexcept {
-        stdexec::set_stopped(std::move(rcvr));
-    }
-
-    KOKKOS_EXECUTION_FORWARDING_GET_ENV(Rcvr, rcvr)
 };
 
-template <typename ExecEnvPolicy, typename Rcvr>
-struct ScheduleFromReceiver<WithoutDelegatedSyncPolicy, ExecEnvPolicy, Rcvr> {
-    using receiver_concept = stdexec::receiver_tag;
+template <typename InnerOp, typename Rcvr>
+concept schedule_from_signals_submitted = Impl::signals_submitted<InnerOp> && Impl::supports_submitted_order_on<Rcvr>;
 
+template <stdexec::receiver Rcvr>
+struct ScheduleFromOpStateBase {
     Rcvr rcvr;
 
-    void set_value() && noexcept {
-        stdexec::set_value(std::move(rcvr));
+    KOKKOS_EXECUTION_GET_ENV(Rcvr, this->rcvr)
+};
+
+template <stdexec::sender Sndr, stdexec::receiver Rcvr>
+struct ScheduleFromOpState
+    : public Impl::Immovable
+    , public ScheduleFromOpStateBase<Rcvr> {
+    using operation_state_concept = Impl::SubmittedOperationStateTag;
+
+    using base_t = ScheduleFromOpStateBase<Rcvr>;
+
+    using exec_env_policy_t = std::conditional_t<
+        execution_space_completing_sender<Sndr, stdexec::__fwd_env_t<stdexec::env_of_t<Rcvr>>>,
+        WithoutExecEnvPolicy,
+        extend_env_with_exec_policy_t<stdexec::env_of_t<Rcvr>>
+    >;
+
+    using rcvr_t = ScheduleFromReceiver<ScheduleFromOpState, stdexec::env_of_t<Rcvr>>;
+
+    using inner_opstate_t = stdexec::connect_result_t<Sndr, rcvr_t>;
+
+    using completion_signal_policy_t = std::conditional_t<
+        schedule_from_signals_submitted<inner_opstate_t, Rcvr>,
+        Impl::SubmittedPolicy::OrderOnExec,
+        Impl::SyncPolicy::InlineFenceExec
+    >;
+
+    inner_opstate_t inner_opstate;
+
+    constexpr explicit ScheduleFromOpState(
+        Sndr&& sndr, // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
+        Rcvr rcvr)
+        noexcept(std::is_nothrow_constructible_v<base_t, Rcvr&&> && stdexec::__nothrow_connectable<Sndr&&, rcvr_t>)
+        : base_t(std::move(rcvr))
+        , inner_opstate(stdexec::connect(std::forward<Sndr>(sndr), rcvr_t{this})) {
+    }
+
+    void complete(stdexec::set_value_t) noexcept {
+        stdexec::set_value(std::move(this->rcvr));
     }
 
     template <typename Error>
-    void set_error(Error&& err) && noexcept {
-        stdexec::set_error(std::move(rcvr), std::forward<Error>(err));
+    void complete(stdexec::set_error_t, Error&& error) noexcept {
+        stdexec::set_error(std::move(this->rcvr), std::forward<Error>(error));
     }
 
-    void set_stopped() && noexcept {
-        stdexec::set_stopped(std::move(rcvr));
+    void complete(stdexec::set_stopped_t) noexcept {
+        stdexec::set_stopped(std::move(this->rcvr));
+    }
+
+    //! Stay in the @ref Kokkos::Execution::ExecutionSpaceImpl::Domain.
+    void submit() noexcept requires std::same_as<completion_signal_policy_t, Impl::SubmittedPolicy::OrderOnExec>
+    {
+        std::move(this->rcvr).submitted();
+    }
+
+    //! Transition to another domain.
+    void submit() noexcept requires std::same_as<completion_signal_policy_t, Impl::SyncPolicy::InlineFenceExec>
+    {
+        try {
+            this->query(Impl::get_exec)
+                .get()
+                .fence(std::string(Impl::dispatch_label<Impl::exec_of_t<decltype(*this)>, ": schedule_from">()));
+            stdexec::set_value(std::move(this->rcvr));
+        } catch (...) {
+            stdexec::set_error(std::move(this->rcvr), std::current_exception());
+        }
     }
 
     [[nodiscard]]
-    constexpr auto get_env() const noexcept -> extend_env_t<ExecEnvPolicy, stdexec::env_of_t<Rcvr>> {
-        return extend_env<ExecEnvPolicy>(stdexec::get_env(this->rcvr));
-    }
-};
-
-template <typename...>
-struct ScheduleFromSender;
-
-//! Sender for @c schedule_from.
-template <stdexec::scheduler Schd, stdexec::sender Sndr>
-struct ScheduleFromSender<WithDelegatedSyncPolicy, Schd, Sndr> {
-    using sender_concept = stdexec::sender_tag;
-
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender)
-
-    template <typename Rcvr>
-    using rcvr_t = ScheduleFromReceiver<WithDelegatedSyncPolicy, WithoutExecEnvPolicy, Schd, Rcvr>;
-
-    template <stdexec::receiver Rcvr>
-    auto connect(Rcvr rcvr) && noexcept(
-        std::is_nothrow_constructible_v<rcvr_t<Rcvr>, Schd&&, Rcvr&&>
-        && stdexec::__nothrow_connectable<Sndr&&, rcvr_t<Rcvr>>) -> stdexec::connect_result_t<Sndr&&, rcvr_t<Rcvr>> {
-        return stdexec::connect(
-            std::forward<Sndr>(sndr), rcvr_t<Rcvr>{.schd = std::move(schd), .rcvr = std::move(rcvr)});
+    constexpr auto query(Impl::get_exec_t) const noexcept -> decltype(auto)
+        requires stdexec::__queryable_with<inner_opstate_t, Impl::get_exec_t>
+    {
+        return Impl::get_exec(inner_opstate);
     }
 
-    KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
-
-    Schd schd;
-    Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    void start() & noexcept {
+        stdexec::start(inner_opstate);
+    }
 };
 
 template <stdexec::sender Sndr>
-struct ScheduleFromSender<WithoutDelegatedSyncPolicy, Sndr> {
+struct ScheduleFromSender {
     using sender_concept = stdexec::sender_tag;
 
     KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender)
 
-    template <typename Rcvr>
-    using rcvr_t = ScheduleFromReceiver<WithoutDelegatedSyncPolicy, exec_env_policy_t<stdexec::env_of_t<Rcvr>>, Rcvr>;
-
     template <stdexec::receiver Rcvr>
-    stdexec::operation_state auto connect(Rcvr rcvr) && noexcept(
-        std::is_nothrow_constructible_v<rcvr_t<Rcvr>, Rcvr&&> && stdexec::__nothrow_connectable<Sndr&&, rcvr_t<Rcvr>>) {
-        return stdexec::connect(std::forward<Sndr>(sndr), rcvr_t<Rcvr>{std::move(rcvr)});
+    constexpr auto
+        connect(Rcvr rcvr) && noexcept(std::is_nothrow_constructible_v<ScheduleFromOpState<Sndr, Rcvr>, Sndr&&, Rcvr&&>)
+            -> ScheduleFromOpState<Sndr, Rcvr> {
+        return ScheduleFromOpState<Sndr, Rcvr>{std::forward<Sndr>(sndr), std::move(rcvr)};
     }
 
     KOKKOS_EXECUTION_IMPL_FORWARDING_ATTRIBUTES_GET_ENV(Sndr, sndr)
@@ -139,27 +134,10 @@ struct ScheduleFromSender<WithoutDelegatedSyncPolicy, Sndr> {
 
 template <>
 struct TransformSenderFor<stdexec::schedule_from_t> {
-    template <typename Sndr, typename Env>
-    using schd_t = Impl::completion_scheduler_of_t<stdexec::set_value_t, Sndr, Env>;
-
-    template <typename Env, execution_space_completing_sender<Env> Sndr>
-    auto operator()(const Env& env, stdexec::schedule_from_t, stdexec::__ignore, Sndr&& sndr) const
-        noexcept(std::is_nothrow_constructible_v<
-                 ScheduleFromSender<WithDelegatedSyncPolicy, schd_t<Sndr, Env>, Sndr>,
-                 schd_t<Sndr, Env>&&,
-                 Sndr&&
-        >) {
-
-        return ScheduleFromSender<WithDelegatedSyncPolicy, schd_t<Sndr, Env>, Sndr>{
-            .schd = stdexec::get_completion_scheduler<stdexec::set_value_t>(stdexec::get_env(sndr), env),
-            .sndr = std::forward<Sndr>(sndr)};
-    }
-
     template <typename Env, typename Sndr>
-    requires(!stdexec::__has_completion_scheduler_for<stdexec::set_value_t, Sndr, Env>)
     auto operator()(const Env&, stdexec::schedule_from_t, stdexec::__ignore, Sndr&& sndr) const
-        noexcept(std::is_nothrow_constructible_v<ScheduleFromSender<WithoutDelegatedSyncPolicy, Sndr>, Sndr&&>) {
-        return ScheduleFromSender<WithoutDelegatedSyncPolicy, Sndr>{.sndr = std::forward<Sndr>(sndr)};
+        noexcept(std::is_nothrow_constructible_v<ScheduleFromSender<Sndr>, Sndr&&>) -> ScheduleFromSender<Sndr> {
+        return {.sndr = std::forward<Sndr>(sndr)};
     }
 };
 

--- a/kokkos-execution/execution_space/when_all.hpp
+++ b/kokkos-execution/execution_space/when_all.hpp
@@ -22,7 +22,8 @@ struct __sexpr_impl<Kokkos::Execution::ExecutionSpaceImpl::when_all_t> : stdexec
     using state_env_t = stdexec::env_of_t<decltype(std::declval<const State&>().__rcvr_)>;
 
     template <typename State>
-    using state_exec_env_policy_t = Kokkos::Execution::ExecutionSpaceImpl::exec_env_policy_t<state_env_t<State>>;
+    using state_exec_env_policy_t =
+        Kokkos::Execution::ExecutionSpaceImpl::extend_env_with_exec_policy_t<state_env_t<State>>;
 
     template <typename State>
     using base_env_t = decltype(base_t::__get_env(stdexec::__ignore{}, std::declval<const State&>()));
@@ -32,9 +33,7 @@ struct __sexpr_impl<Kokkos::Execution::ExecutionSpaceImpl::when_all_t> : stdexec
 
     template <typename State>
     struct get_env_impl<Kokkos::Execution::ExecutionSpaceImpl::WithExecEnvPolicy, State> {
-        using execution_space = typename std::remove_cvref_t<
-            stdexec::__query_result_t<state_env_t<State>, Kokkos::Execution::Impl::get_exec_t>
-        >::execution_space;
+        using execution_space = Kokkos::Execution::Impl::exec_of_t<state_env_t<State>>;
 
         using type = decltype(Kokkos::Execution::ExecutionSpaceImpl::join_env_with_exec(
             std::declval<base_env_t<State>>(),

--- a/kokkos-execution/graph/operation_state.hpp
+++ b/kokkos-execution/graph/operation_state.hpp
@@ -187,6 +187,10 @@ struct OpState
         }
     }
 
+    void complete(stdexec::set_value_t) noexcept {
+        this->submit();
+    }
+
     void submit() noexcept {
         if constexpr (after_root) {
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)

--- a/kokkos-execution/impl/Cuda/dependency.hpp
+++ b/kokkos-execution/impl/Cuda/dependency.hpp
@@ -1,0 +1,36 @@
+#ifndef KOKKOS_EXECUTION_IMPL_CUDA_DEPENDENCY_HPP
+#define KOKKOS_EXECUTION_IMPL_CUDA_DEPENDENCY_HPP
+
+#include "kokkos-execution/impl/event.hpp"
+
+/**
+ * @file
+ *
+ * Specialization of types from @ref kokkos-execution/impl/dependency.hpp for @c Kokkos::Cuda.
+ */
+
+namespace Kokkos::Execution::Impl {
+
+template <>
+struct HasExecWaitEvent<Kokkos::Cuda> : std::true_type { };
+
+template <>
+struct DependencyWithEvent<Kokkos::Cuda> {
+    Event<Kokkos::Cuda> event{};
+
+    DependencyWithEvent(const Kokkos::Cuda& exec_to, const Kokkos::Cuda& exec_from) {
+        if (exec_from != exec_to) {
+            record(event, exec_from);
+            wait(exec_to, event);
+        }
+    }
+};
+
+template <>
+struct Dependency<Kokkos::Cuda, Kokkos::Cuda> : public DependencyWithEvent<Kokkos::Cuda> {
+    using DependencyWithEvent<Kokkos::Cuda>::DependencyWithEvent;
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_CUDA_DEPENDENCY_HPP

--- a/kokkos-execution/impl/Cuda/event.hpp
+++ b/kokkos-execution/impl/Cuda/event.hpp
@@ -42,12 +42,17 @@ struct Event<Kokkos::Cuda> {
             KOKKOS_IMPL_CUDA_SAFE_CALL(cudaEventSynchronize(m_event));
         }
     }
+
+    [[nodiscard]]
+    constexpr cudaEvent_t cuda_event() const noexcept {
+        return m_event;
+    }
 };
 
 template <>
 void impl_wait(const Kokkos::Cuda& exec, const Event<Kokkos::Cuda>& event) {
-    KOKKOS_EXPECTS(bool(event.m_event));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamWaitEvent(exec.cuda_stream(), event.m_event));
+    KOKKOS_EXPECTS(bool(event.cuda_event()));
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamWaitEvent(exec.cuda_stream(), event.cuda_event()));
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/HIP/dependency.hpp
+++ b/kokkos-execution/impl/HIP/dependency.hpp
@@ -1,0 +1,36 @@
+#ifndef KOKKOS_EXECUTION_IMPL_HIP_DEPENDENCY_HPP
+#define KOKKOS_EXECUTION_IMPL_HIP_DEPENDENCY_HPP
+
+#include "kokkos-execution/impl/event.hpp"
+
+/**
+ * @file
+ *
+ * Specialization of types from @ref kokkos-execution/impl/dependency.hpp for @c Kokkos::HIP.
+ */
+
+namespace Kokkos::Execution::Impl {
+
+template <>
+struct HasExecWaitEvent<Kokkos::HIP> : std::true_type { };
+
+template <>
+struct DependencyWithEvent<Kokkos::HIP> {
+    Event<Kokkos::HIP> event{};
+
+    DependencyWithEvent(const Kokkos::HIP& exec_to, const Kokkos::HIP& exec_from) {
+        if (exec_from != exec_to) {
+            record(event, exec_from);
+            wait(exec_to, event);
+        }
+    }
+};
+
+template <>
+struct Dependency<Kokkos::HIP, Kokkos::HIP> : public DependencyWithEvent<Kokkos::HIP> {
+    using DependencyWithEvent<Kokkos::HIP>::DependencyWithEvent;
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_HIP_DEPENDENCY_HPP

--- a/kokkos-execution/impl/HIP/event.hpp
+++ b/kokkos-execution/impl/HIP/event.hpp
@@ -42,12 +42,17 @@ struct Event<Kokkos::HIP> {
             KOKKOS_IMPL_HIP_SAFE_CALL(hipEventSynchronize(m_event));
         }
     }
+
+    [[nodiscard]]
+    constexpr hipEvent_t hip_event() const noexcept {
+        return m_event;
+    }
 };
 
 template <>
 void impl_wait(const Kokkos::HIP& exec, const Event<Kokkos::HIP>& event) {
-    KOKKOS_EXPECTS(bool(event.m_event));
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamWaitEvent(exec.hip_stream(), event.m_event));
+    KOKKOS_EXPECTS(bool(event.hip_event()));
+    KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamWaitEvent(exec.hip_stream(), event.hip_event()));
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/SYCL/dependency.hpp
+++ b/kokkos-execution/impl/SYCL/dependency.hpp
@@ -1,0 +1,36 @@
+#ifndef KOKKOS_EXECUTION_IMPL_SYCL_DEPENDENCY_HPP
+#define KOKKOS_EXECUTION_IMPL_SYCL_DEPENDENCY_HPP
+
+#include "kokkos-execution/impl/event.hpp"
+
+/**
+ * @file
+ *
+ * Specialization of types from @ref kokkos-execution/impl/dependency.hpp for @c Kokkos::SYCL.
+ */
+
+namespace Kokkos::Execution::Impl {
+
+template <>
+struct HasExecWaitEvent<Kokkos::SYCL> : std::true_type { };
+
+template <>
+struct DependencyWithEvent<Kokkos::SYCL> {
+    Event<Kokkos::SYCL> event{};
+
+    DependencyWithEvent(const Kokkos::SYCL& exec_to, const Kokkos::SYCL& exec_from) {
+        if (exec_from != exec_to) {
+            record(event, exec_from);
+            wait(exec_to, event);
+        }
+    }
+};
+
+template <>
+struct Dependency<Kokkos::SYCL, Kokkos::SYCL> : public DependencyWithEvent<Kokkos::SYCL> {
+    using DependencyWithEvent<Kokkos::SYCL>::DependencyWithEvent;
+};
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_SYCL_DEPENDENCY_HPP

--- a/kokkos-execution/impl/SYCL/event.hpp
+++ b/kokkos-execution/impl/SYCL/event.hpp
@@ -39,12 +39,17 @@ struct Event<Kokkos::SYCL> {
             m_event = std::nullopt;
         }
     }
+
+    [[nodiscard]]
+    constexpr const sycl::event& sycl_event() const noexcept {
+        KOKKOS_EXPECTS(m_event.has_value());
+        return *m_event;
+    }
 };
 
 template <>
 void impl_wait(const Kokkos::SYCL& exec, const Event<Kokkos::SYCL>& event) {
-    KOKKOS_EXPECTS(event.m_event.has_value());
-    exec.sycl_queue().submit([&](sycl::handler& cgh) { cgh.depends_on(*event.m_event); });
+    exec.sycl_queue().submit([&](sycl::handler& cgh) { cgh.depends_on(event.sycl_event()); });
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/completion_signal.hpp
+++ b/kokkos-execution/impl/completion_signal.hpp
@@ -31,11 +31,7 @@ struct RequiresSync {
     bool operator()(const Exec& exec, const Rcvr& rcvr) const noexcept
         requires(stdexec::__queryable_with<stdexec::env_of_t<Rcvr>, get_exec_t>)
     {
-        if constexpr (
-            std::same_as<
-                std::remove_cvref_t<stdexec::__query_result_t<stdexec::env_of_t<Rcvr>, get_exec_t>>,
-                ExecutionSpaceRef<Exec>
-            >) {
+        if constexpr (std::same_as<exec_of_t<stdexec::env_of_t<Rcvr>>, Exec>) {
             const auto& src = exec;
             const auto& dst = get_exec(stdexec::get_env(rcvr)).get();
 #if defined(KOKKOS_EXECUTION_ENABLE_DEBUG_LOGGING)

--- a/kokkos-execution/impl/dependency.hpp
+++ b/kokkos-execution/impl/dependency.hpp
@@ -1,0 +1,60 @@
+#ifndef KOKKOS_EXECUTION_IMPL_DEPENDENCY_HPP
+#define KOKKOS_EXECUTION_IMPL_DEPENDENCY_HPP
+
+#include "Kokkos_Core.hpp"
+
+#include "kokkos-execution/impl/dispatch_label.hpp"
+
+namespace Kokkos::Execution::Impl {
+
+/**
+ * @brief This is the default implementation.
+ *
+ * Create a dependency between operations enqueud into one execution space instance @p exec_from (from any thread)
+ * with those that will be enqueud into another execution space instance @p exec_to.
+ *
+ * The dependency results in the same semantic guarantees as a @c Kokkos fence, *i.e.* it
+ * guarantees both the ordering and the side effects visibility.
+ *
+ * References:
+ *  - https://kokkos.org/kokkos-core-wiki/API/core/parallel-dispatch/fence.html#semantics
+ */
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
+struct Dependency {
+    Dependency(const ExecTo&, const ExecFrom& exec_from) {
+        exec_from.fence(std::string(Impl::dispatch_label<ExecFrom, ": dependency">()));
+    }
+};
+
+template <Kokkos::ExecutionSpace Exec>
+struct Dependency<Exec, Exec> {
+    Dependency(const Exec& exec_to, const Exec& exec_from) {
+        if (exec_from != exec_to) {
+            exec_from.fence(std::string(Impl::dispatch_label<Exec, ": dependency">()));
+        }
+    }
+};
+
+template <Kokkos::ExecutionSpace>
+struct DependencyWithEvent;
+
+template <Kokkos::ExecutionSpace Exec>
+struct HasExecWaitEvent : std::false_type { };
+
+//! Determine if the @c Kokkos backend can enqueue a wait for an event in an execution space instance.
+template <typename Exec>
+concept has_exec_wait_event = HasExecWaitEvent<Exec>::value;
+
+} // namespace Kokkos::Execution::Impl
+
+#if defined(KOKKOS_ENABLE_CUDA)
+#    include "kokkos-execution/impl/Cuda/dependency.hpp"
+#endif
+#if defined(KOKKOS_ENABLE_HIP)
+#    include "kokkos-execution/impl/HIP/dependency.hpp"
+#endif
+#if defined(KOKKOS_ENABLE_SYCL)
+#    include "kokkos-execution/impl/SYCL/dependency.hpp"
+#endif
+
+#endif // KOKKOS_EXECUTION_IMPL_DEPENDENCY_HPP

--- a/kokkos-execution/impl/empty.hpp
+++ b/kokkos-execution/impl/empty.hpp
@@ -1,0 +1,10 @@
+#ifndef KOKKOS_EXECUTION_IMPL_EMTPY_HPP
+#define KOKKOS_EXECUTION_IMPL_EMTPY_HPP
+
+namespace Kokkos::Execution::Impl {
+
+struct Empty { };
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_EMTPY_HPP

--- a/kokkos-execution/impl/event.hpp
+++ b/kokkos-execution/impl/event.hpp
@@ -149,7 +149,7 @@ void wait(const Event<Exec>& event) {
     event.wait();
 }
 
-template <Kokkos::ExecutionSpace ExecFrom, Kokkos::ExecutionSpace ExecTo>
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
 void impl_wait(const ExecTo&, const Event<ExecFrom>& event) {
     event.wait();
 }
@@ -159,7 +159,7 @@ void impl_wait(const ExecTo&, const Event<ExecFrom>& event) {
  *
  * @note Backends should specialize @ref impl_wait.
  */
-template <Kokkos::ExecutionSpace ExecFrom, Kokkos::ExecutionSpace ExecTo>
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
 void wait(const ExecTo& exec, const Event<ExecFrom>& event) {
     wait_event(exec, event);
     impl_wait(exec, event);

--- a/kokkos-execution/impl/get_exec.hpp
+++ b/kokkos-execution/impl/get_exec.hpp
@@ -3,6 +3,8 @@
 
 #include "Kokkos_Core.hpp"
 
+#include "kokkos-execution/impl/sender_introspection.hpp"
+
 namespace Kokkos::Execution::Impl {
 
 /**
@@ -15,6 +17,24 @@ struct get_exec_t : public stdexec::__query<get_exec_t> {
 };
 
 inline constexpr get_exec_t get_exec{};
+
+template <typename... Args>
+struct ExecOf;
+
+//! Type of the execution space extracted from @p Sndr completion scheduler.
+template <stdexec::sender Sndr, typename... Env>
+struct ExecOf<Sndr, Env...> {
+    using type = typename completion_scheduler_of_t<stdexec::set_value_t, Sndr, Env...>::execution_space;
+};
+
+//! Type of the execution space extracted from a @ref get_exec_t query on @p T.
+template <stdexec::__queryable_with<get_exec_t> T>
+struct ExecOf<T> {
+    using type = typename std::remove_cvref_t<stdexec::__query_result_t<T, get_exec_t>>::execution_space;
+};
+
+template <typename... Args>
+using exec_of_t = typename ExecOf<Args...>::type;
 
 /**
  * @brief Wrap a @c Kokkos execution space to make it cheap to copy/move in new environments.

--- a/kokkos-execution/impl/receiver.hpp
+++ b/kokkos-execution/impl/receiver.hpp
@@ -16,7 +16,7 @@ struct Receiver {
     ParentOp* parent_op;
 
     void set_value() && noexcept {
-        parent_op->submit();
+        parent_op->complete(stdexec::set_value);
     }
 
     template <typename Error>

--- a/kokkos-execution/impl/sender_introspection.hpp
+++ b/kokkos-execution/impl/sender_introspection.hpp
@@ -18,10 +18,6 @@ template <typename Tag, stdexec::sender Sndr, typename... Env>
 using completion_scheduler_of_t =
     std::invoke_result_t<stdexec::get_completion_scheduler_t<Tag>, stdexec::env_of_t<Sndr>, Env...>;
 
-//! Type of the execution space extracted from a sender's completion scheduler.
-template <typename Sndr, typename... Env>
-using exec_of_t = typename completion_scheduler_of_t<stdexec::set_value_t, Sndr, Env...>::execution_space;
-
 //! Check that a sender has one child.
 template <typename Sndr>
 concept has_child = requires {

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -47,14 +47,9 @@ class ContinuesOnTest
 
 //! @test Check traits of the sender created by the customized @c stdexec::schedule_from.
 consteval bool test_schedule_from_sndr_traits() {
-    using schd_t = typename ContinuesOnTest::scheduler_t;
     using schd_sndr_t = typename ContinuesOnTest::schedule_sender_t;
 
-    using schedule_from_sndr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromSender<
-        Kokkos::Execution::ExecutionSpaceImpl::WithDelegatedSyncPolicy,
-        schd_t,
-        schd_sndr_t
-    >;
+    using schedule_from_sndr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromSender<schd_sndr_t>;
 
     static_assert(stdexec::__nothrow_connectable<schedule_from_sndr_t, Tests::Utils::SinkReceiver>);
 
@@ -132,8 +127,9 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
 
     /**
      * The environment of the receiver created by the customization of the most downstream @c then
-     * is queryable with @ref Kokkos::Execution::Impl::get_exec_t.
+     * is not queryable with @ref Kokkos::Execution::Impl::get_exec_t.
      */
+    const auto& then_opstate = op_state;
     using then_rcvr_t = Kokkos::Execution::Impl::Receiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
         Kokkos::Execution::Impl::SyncWait::Receiver<host_execution_space, std::true_type>,
         Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
@@ -142,16 +138,16 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
             Kokkos::RangePolicy<host_execution_space, Kokkos::LaunchBounds<1>>
         >
     >>;
-    static_assert(std::same_as<decltype(op_state.inner_opstate.completion_signal.rcvr.rcvr.rcvr), then_rcvr_t>);
+    static_assert(std::same_as<decltype(then_opstate.inner_opstate.rcvr), then_rcvr_t>);
     static_assert(!stdexec::__queryable_with<stdexec::env_of_t<then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
 
     //! Our customization of @c continues_on forwards the environment.
-    using con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<
-        Kokkos::Execution::ExecutionSpaceImpl::WithExecEnvPolicy,
-        Kokkos::Execution::ExecutionSpaceImpl::Scheduler<host_execution_space>,
-        then_rcvr_t
-    >;
-    static_assert(std::same_as<decltype(op_state.inner_opstate.completion_signal.rcvr.rcvr), con_h_then_rcvr_t>);
+    const auto& con_h_then_opstate = then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnOpState
+    >);
+    using con_h_then_rcvr_t = decltype(con_h_then_opstate.inner_opstate.rcvr);
     static_assert(stdexec::__queryable_with<stdexec::env_of_t<con_h_then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
     static_assert(std::same_as<
                   stdexec::env_of_t<con_h_then_rcvr_t>,
@@ -163,48 +159,34 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
                       stdexec::__env::__fwd<Kokkos::Execution::Impl::SyncWait::env>
                   >
     >);
-    ASSERT_EQ(
-        Kokkos::Execution::Impl::get_exec(stdexec::get_env(op_state.inner_opstate.completion_signal.rcvr.rcvr)).get(),
-        exec_h);
+    ASSERT_EQ(Kokkos::Execution::Impl::get_exec(stdexec::get_env(con_h_then_opstate.inner_opstate.rcvr)).get(), exec_h);
 
-    //! @ref Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver updates the @ref Kokkos::Execution::Impl::get_exec_t query.
-    using sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver<
-        Kokkos::Execution::ExecutionSpaceImpl::WithDelegatedSyncPolicy,
-        Kokkos::Execution::ExecutionSpaceImpl::WithoutExecEnvPolicy,
-        scheduler_t,
-        con_h_then_rcvr_t
-    >;
-    static_assert(std::same_as<decltype(op_state.inner_opstate.completion_signal.rcvr), sfrom_con_h_then_rcvr_t>);
+    const auto& sfrom_con_h_then_opstate = con_h_then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(sfrom_con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromOpState
+    >);
+    using sfrom_con_h_then_rcvr_t = decltype(sfrom_con_h_then_opstate.inner_opstate.completion_signal.rcvr);
     static_assert(
         !stdexec::__queryable_with<stdexec::env_of_t<sfrom_con_h_then_rcvr_t>, Kokkos::Execution::Impl::get_exec_t>);
 
-    using then_sfrom_con_h_then_rcvr_t =
-        Kokkos::Execution::Impl::Receiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
-            sfrom_con_h_then_rcvr_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                std::string_view,
-                Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'B'>>,
-                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
-            >
-        >>;
-    static_assert(std::same_as<
-                  decltype(op_state.inner_opstate.inner_opstate.completion_signal.rcvr.rcvr.rcvr),
-                  then_sfrom_con_h_then_rcvr_t
+    const auto& then_sfrom_con_h_then_opstate = sfrom_con_h_then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(then_sfrom_con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::OpState
     >);
+    using then_sfrom_con_h_then_rcvr_t = decltype(then_sfrom_con_h_then_opstate.inner_opstate.rcvr);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<then_sfrom_con_h_then_rcvr_t>,
                   Kokkos::Execution::Impl::get_exec_t
     >);
 
-    using con_B_then_sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnReceiver<
-        Kokkos::Execution::ExecutionSpaceImpl::WithExecEnvPolicy,
-        scheduler_t,
-        then_sfrom_con_h_then_rcvr_t
-    >;
-    static_assert(std::same_as<
-                  decltype(op_state.inner_opstate.inner_opstate.completion_signal.rcvr.rcvr),
-                  con_B_then_sfrom_con_h_then_rcvr_t
+    const auto& con_B_then_sfrom_con_h_then_opstate = then_sfrom_con_h_then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(con_B_then_sfrom_con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::ContinuesOnOpState
     >);
+    using con_B_then_sfrom_con_h_then_rcvr_t = decltype(con_B_then_sfrom_con_h_then_opstate.inner_opstate.rcvr);
     static_assert(stdexec::__queryable_with<
                   stdexec::env_of_t<con_B_then_sfrom_con_h_then_rcvr_t>,
                   Kokkos::Execution::Impl::get_exec_t
@@ -226,39 +208,29 @@ TEST_F(ContinuesOnTest, queryable_get_exec) {
                   >
     >);
     ASSERT_EQ(
-        Kokkos::Execution::Impl::get_exec(
-            stdexec::get_env(op_state.inner_opstate.inner_opstate.completion_signal.rcvr.rcvr))
+        Kokkos::Execution::Impl::get_exec(stdexec::get_env(con_B_then_sfrom_con_h_then_opstate.inner_opstate.rcvr))
             .get(),
         exec_B);
 
-    using sfrom_con_B_then_sfrom_con_h_then_rcvr_t = Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromReceiver<
-        Kokkos::Execution::ExecutionSpaceImpl::WithDelegatedSyncPolicy,
-        Kokkos::Execution::ExecutionSpaceImpl::WithoutExecEnvPolicy,
-        scheduler_t,
-        con_B_then_sfrom_con_h_then_rcvr_t
-    >;
-    static_assert(std::same_as<
-                  decltype(op_state.inner_opstate.inner_opstate.completion_signal.rcvr),
-                  sfrom_con_B_then_sfrom_con_h_then_rcvr_t
+    const auto& sfrom_con_B_then_sfrom_con_h_then_opstate = con_B_then_sfrom_con_h_then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(sfrom_con_B_then_sfrom_con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::ScheduleFromOpState
     >);
+    using sfrom_con_B_then_sfrom_con_h_then_rcvr_t = decltype(sfrom_con_B_then_sfrom_con_h_then_opstate.inner_opstate
+                                                                  .completion_signal.rcvr);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<sfrom_con_B_then_sfrom_con_h_then_rcvr_t>,
                   Kokkos::Execution::Impl::get_exec_t
     >);
 
-    using then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t =
-        Kokkos::Execution::Impl::Receiver<Kokkos::Execution::ExecutionSpaceImpl::OpStateBase<
-            sfrom_con_B_then_sfrom_con_h_then_rcvr_t,
-            Kokkos::Execution::ExecutionSpaceImpl::ParallelForClosure<
-                std::string_view,
-                Kokkos::Execution::ExecutionSpaceImpl::ThenWrapper<Tests::Utils::Functors::Labeled<'A'>>,
-                Kokkos::RangePolicy<TEST_EXECUTION_SPACE, Kokkos::LaunchBounds<1>>
-            >
-        >>;
-    static_assert(std::same_as<
-                  decltype(op_state.inner_opstate.inner_opstate.inner_opstate.rcvr),
-                  then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t
+    const auto& then_sfrom_B_then_sfrom_con_h_then_opstate = sfrom_con_B_then_sfrom_con_h_then_opstate.inner_opstate;
+    static_assert(stdexec::__is_instance_of<
+                  std::remove_cvref_t<decltype(then_sfrom_B_then_sfrom_con_h_then_opstate)>,
+                  Kokkos::Execution::ExecutionSpaceImpl::OpState
     >);
+    using then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t = decltype(then_sfrom_B_then_sfrom_con_h_then_opstate
+                                                                       .inner_opstate.rcvr);
     static_assert(!stdexec::__queryable_with<
                   stdexec::env_of_t<then_sfrom_con_B_then_sfrom_con_h_then_rcvr_t>,
                   Kokkos::Execution::Impl::get_exec_t
@@ -334,24 +306,38 @@ TEST_F(ContinuesOnTest, transition_to_another_execution_space_instance_and_back_
 
     const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(chain));
 
-    if (Tests::Utils::are_same_instances(exec_A, exec_B)) {
+    if constexpr (Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>) {
         ASSERT_THAT(
             recorded_events,
             ::testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_A),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(1)),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_B),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_A, recorded_events.at(4)),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            ::testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "schedule_from")),
-                MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec, "schedule_from")),
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        if (Tests::Utils::are_same_instances(exec_A, exec_B)) {
+            ASSERT_THAT(
+                recorded_events,
+                ::testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        } else {
+            ASSERT_THAT(
+                recorded_events,
+                ::testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "dependency")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec, "dependency")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        }
     }
 
     ASSERT_EQ(data(), 3) << "A synchronization is missing.";
@@ -410,9 +396,9 @@ TEST_F(ContinuesOnTest, transition_to_another_execution_space_instance_and_back_
             recorded_events,
             ::testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "dependency")),
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "schedule_from")),
+                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "dependency")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     }

--- a/tests/execution_space/test_on.cpp
+++ b/tests/execution_space/test_on.cpp
@@ -98,24 +98,38 @@ TEST_F(OnTest, on_another_execution_space_instance_same_type) {
 
     const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(chain));
 
-    if (Tests::Utils::are_same_instances(exec_A, exec_B)) {
+    if constexpr (Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>) {
         ASSERT_THAT(
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_A),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(1)),
                 MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_B),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_A, recorded_events.at(4)),
                 MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
     } else {
-        ASSERT_THAT(
-            recorded_events,
-            testing::ElementsAre(
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "schedule_from")),
-                MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec, "schedule_from")),
-                MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        if (Tests::Utils::are_same_instances(exec_A, exec_B)) {
+            ASSERT_THAT(
+                recorded_events,
+                testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        } else {
+            ASSERT_THAT(
+                recorded_events,
+                testing::ElementsAre(
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "dependency")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_B, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_B, dispatch_label(exec, "dependency")),
+                    MATCHER_FOR_BEGIN_PFOR(exec_A, dispatch_label(exec, "then")),
+                    MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec, "sync_wait"))));
+        }
     }
 
     ASSERT_EQ(data(), 3) << "A synchronization is missing.";
@@ -158,9 +172,9 @@ TEST_F(OnTest, many_execution_space_instances_of_different_type) {
             recorded_events,
             testing::ElementsAre(
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "schedule_from")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "dependency")),
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
-                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "schedule_from")),
+                MATCHER_FOR_BEGIN_FENCE(exec_h, dispatch_label(exec_h, "dependency")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     }

--- a/tests/impl/CMakeLists.txt
+++ b/tests/impl/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_one_test(NAME completion_signal)
+add_one_test(NAME dependency ADDITIONAL_LINK_LIBRARIES GTest::gmock)
 add_one_test(NAME env)
 add_one_test(NAME event ADDITIONAL_LINK_LIBRARIES GTest::gmock)
 add_one_test(NAME sender_introspection)

--- a/tests/impl/test_dependency.cpp
+++ b/tests/impl/test_dependency.cpp
@@ -1,0 +1,81 @@
+#include "gtest/gtest.h"
+
+#include "kokkos-utils/callbacks/RecorderListener.hpp"
+#include "kokkos-utils/tests/scoped/callbacks/Manager.hpp"
+
+#include "kokkos-execution/impl/dependency.hpp"
+#include "kokkos-execution/impl/event.hpp"
+
+#include "tests/utils/callback_matchers.hpp"
+#include "tests/utils/execution_space_context.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Dependency
+ * ----------
+ *
+ * This group of tests check @ref Kokkos::Execution::Impl::Dependency.
+ *
+ * The tests can be found in @ref tests/impl/test_dependency.cpp.
+ */
+
+#if !defined(KOKKOS_EXECUTION_ENABLE_EVENT_DISPATCH)
+#    error "This is not supported."
+#endif
+
+namespace Tests::Impl {
+
+using namespace Kokkos::utils::callbacks;
+
+class DependencyTest
+    : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE>
+    , public Kokkos::utils::tests::scoped::callbacks::Manager {
+   public:
+    using recorder_listener_t = RecorderListener<
+        EventDiscardMatcher<TEST_EXECUTION_SPACE>,
+        BeginFenceEvent,
+        Kokkos::Execution::Impl::RecordEvent,
+        Kokkos::Execution::Impl::WaitEvent
+    >;
+};
+
+//! @test Check @ref Kokkos::Execution::Impl::Dependency when the underlying execution space type is the same.
+TEST_F(DependencyTest, same_type) {
+    const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
+
+    const auto recorded_events = recorder_listener_t::record(
+        [&exec_A, &exec_B]() { Kokkos::Execution::Impl::Dependency{exec_B, exec_A}; });
+
+    if constexpr (Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>) {
+        ASSERT_THAT(recorded_events, ::testing::SizeIs(2));
+        ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec_A));
+        ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(0)));
+    } else {
+        if (Tests::Utils::are_same_instances(exec_A, exec_B)) {
+            ASSERT_THAT(recorded_events, testing::IsEmpty());
+        } else {
+            ASSERT_THAT(
+                recorded_events,
+                testing::ElementsAre(MATCHER_FOR_BEGIN_FENCE(exec_A, dispatch_label(exec_A, "dependency"))));
+        }
+    }
+}
+
+//! @test Check @ref Kokkos::Execution::Impl::Dependency when the underlying execution space type is different.
+TEST_F(DependencyTest, different_type) {
+    if constexpr (std::same_as<TEST_EXECUTION_SPACE, Kokkos::DefaultHostExecutionSpace>) {
+        GTEST_SKIP() << "The default host execution space is the same type as the test execution space.";
+    }
+
+    const Kokkos::DefaultHostExecutionSpace exec_h;
+
+    const auto recorded_events = recorder_listener_t::record(
+        [this, &exec_h]() { Kokkos::Execution::Impl::Dependency{exec_h, this->exec}; });
+
+    ASSERT_THAT(
+        recorded_events,
+        testing::ElementsAre(MATCHER_FOR_BEGIN_FENCE(this->exec, dispatch_label(this->exec, "dependency"))));
+}
+
+} // namespace Tests::Impl


### PR DESCRIPTION
This PR introduces a `Dependency` type, whose goal is to handle a "dependency" between operations submitted to an execution space instance A and another B.

It's used to enhance our continues_on/schedule_from.

For instance, it boils down to a `cudaStreamWaitEvent` for CUDA.