### PR TITLE
cicd: smoke test on release

### DIFF
--- a/.github/workflows/build.images.yml
+++ b/.github/workflows/build.images.yml
@@ -119,11 +119,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - compiler:
-              family: gnu
-              version: 14
-            base_image: ubuntu:24.04
-            platforms: linux/amd64
+          - {compiler: {family: gnu, version: 14}, base_image: ubuntu:24.04, platforms: linux/amd64, cmake_build_type: Debug}
           - kokkos_backends: [Threads]
             compiler:
               family: gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - {compiler: {family: gnu, version: 14}}
+          - {compiler: {family: gnu, version: 14}, cmake_build_type: Debug}
     container:
-      image: ${{ needs.build-images.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}
+      image: ${{ needs.build-images.outputs.CI_IMAGE }}:${{ matrix.compiler.family }}-${{ matrix.compiler.version }}-${{ matrix.cmake_build_type }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,7 +62,7 @@ jobs:
           ccache --set-config=base_dir=$GITHUB_WORKSPACE
           ccache --set-config=cache_dir=$GITHUB_WORKSPACE/.ccache
       - run: ccache --verbose --show-stats
-      - run: cmake -S . --preset=${{ matrix.compiler.family }}
+      - run: cmake -S . --preset=${{ matrix.compiler.family }} -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }}
       - run: cmake --build --preset=${{ matrix.compiler.family }} -j4
       - run: ctest --preset=${{ matrix.compiler.family }}
       - run: bash tests/install_test.sh ${{ matrix.compiler.family }} ${{ matrix.compiler.family }}


### PR DESCRIPTION
This PR moves the smoke test to a debug build.
It also solves the latent issue that the smoke test was using the old `gnu-14` image, i.e. without the cmake build type.