### PR TITLE
impl(dependency): use `has_exec_wait_event` as a "execution space property"

### DIFF
--- a/kokkos-execution/impl/Cuda/dependency.hpp
+++ b/kokkos-execution/impl/Cuda/dependency.hpp
@@ -1,8 +1,6 @@
 #ifndef KOKKOS_EXECUTION_IMPL_CUDA_DEPENDENCY_HPP
 #define KOKKOS_EXECUTION_IMPL_CUDA_DEPENDENCY_HPP
 
-#include "kokkos-execution/impl/event.hpp"
-
 /**
  * @file
  *
@@ -13,23 +11,6 @@ namespace Kokkos::Execution::Impl {
 
 template <>
 struct HasExecWaitEvent<Kokkos::Cuda> : std::true_type { };
-
-template <>
-struct DependencyWithEvent<Kokkos::Cuda> {
-    Event<Kokkos::Cuda> event{};
-
-    DependencyWithEvent(const Kokkos::Cuda& exec_to, const Kokkos::Cuda& exec_from) {
-        if (exec_from != exec_to) {
-            record(event, exec_from);
-            wait(exec_to, event);
-        }
-    }
-};
-
-template <>
-struct Dependency<Kokkos::Cuda, Kokkos::Cuda> : public DependencyWithEvent<Kokkos::Cuda> {
-    using DependencyWithEvent<Kokkos::Cuda>::DependencyWithEvent;
-};
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/HIP/dependency.hpp
+++ b/kokkos-execution/impl/HIP/dependency.hpp
@@ -1,8 +1,6 @@
 #ifndef KOKKOS_EXECUTION_IMPL_HIP_DEPENDENCY_HPP
 #define KOKKOS_EXECUTION_IMPL_HIP_DEPENDENCY_HPP
 
-#include "kokkos-execution/impl/event.hpp"
-
 /**
  * @file
  *
@@ -13,23 +11,6 @@ namespace Kokkos::Execution::Impl {
 
 template <>
 struct HasExecWaitEvent<Kokkos::HIP> : std::true_type { };
-
-template <>
-struct DependencyWithEvent<Kokkos::HIP> {
-    Event<Kokkos::HIP> event{};
-
-    DependencyWithEvent(const Kokkos::HIP& exec_to, const Kokkos::HIP& exec_from) {
-        if (exec_from != exec_to) {
-            record(event, exec_from);
-            wait(exec_to, event);
-        }
-    }
-};
-
-template <>
-struct Dependency<Kokkos::HIP, Kokkos::HIP> : public DependencyWithEvent<Kokkos::HIP> {
-    using DependencyWithEvent<Kokkos::HIP>::DependencyWithEvent;
-};
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/SYCL/dependency.hpp
+++ b/kokkos-execution/impl/SYCL/dependency.hpp
@@ -1,8 +1,6 @@
 #ifndef KOKKOS_EXECUTION_IMPL_SYCL_DEPENDENCY_HPP
 #define KOKKOS_EXECUTION_IMPL_SYCL_DEPENDENCY_HPP
 
-#include "kokkos-execution/impl/event.hpp"
-
 /**
  * @file
  *
@@ -13,23 +11,6 @@ namespace Kokkos::Execution::Impl {
 
 template <>
 struct HasExecWaitEvent<Kokkos::SYCL> : std::true_type { };
-
-template <>
-struct DependencyWithEvent<Kokkos::SYCL> {
-    Event<Kokkos::SYCL> event{};
-
-    DependencyWithEvent(const Kokkos::SYCL& exec_to, const Kokkos::SYCL& exec_from) {
-        if (exec_from != exec_to) {
-            record(event, exec_from);
-            wait(exec_to, event);
-        }
-    }
-};
-
-template <>
-struct Dependency<Kokkos::SYCL, Kokkos::SYCL> : public DependencyWithEvent<Kokkos::SYCL> {
-    using DependencyWithEvent<Kokkos::SYCL>::DependencyWithEvent;
-};
 
 } // namespace Kokkos::Execution::Impl
 

--- a/kokkos-execution/impl/dependency.hpp
+++ b/kokkos-execution/impl/dependency.hpp
@@ -4,8 +4,16 @@
 #include "Kokkos_Core.hpp"
 
 #include "kokkos-execution/impl/dispatch_label.hpp"
+#include "kokkos-execution/impl/event.hpp"
 
 namespace Kokkos::Execution::Impl {
+
+template <Kokkos::ExecutionSpace Exec>
+struct HasExecWaitEvent : std::false_type { };
+
+//! Determine if the @c Kokkos backend can enqueue a wait for an event into an execution space instance.
+template <typename Exec>
+concept has_exec_wait_event = HasExecWaitEvent<Exec>::value;
 
 /**
  * @brief This is the default implementation.
@@ -27,6 +35,7 @@ struct Dependency {
 };
 
 template <Kokkos::ExecutionSpace Exec>
+requires(!has_exec_wait_event<Exec>)
 struct Dependency<Exec, Exec> {
     Dependency(const Exec& exec_to, const Exec& exec_from) {
         if (exec_from != exec_to) {
@@ -35,15 +44,18 @@ struct Dependency<Exec, Exec> {
     }
 };
 
-template <Kokkos::ExecutionSpace>
-struct DependencyWithEvent;
-
 template <Kokkos::ExecutionSpace Exec>
-struct HasExecWaitEvent : std::false_type { };
+requires has_exec_wait_event<Exec>
+struct Dependency<Exec, Exec> {
+    Event<Exec> event{};
 
-//! Determine if the @c Kokkos backend can enqueue a wait for an event in an execution space instance.
-template <typename Exec>
-concept has_exec_wait_event = HasExecWaitEvent<Exec>::value;
+    Dependency(const Exec& exec_to, const Exec& exec_from) {
+        if (exec_from != exec_to) {
+            record(event, exec_from);
+            wait(exec_to, event);
+        }
+    }
+};
 
 } // namespace Kokkos::Execution::Impl
 

--- a/tests/impl/test_event.cpp
+++ b/tests/impl/test_event.cpp
@@ -53,6 +53,22 @@ consteval bool test_models_event() {
 }
 static_assert(test_models_event<TEST_EXECUTION_SPACE>());
 
+//! @test Check @ref Kokkos::Execution::Impl::has_exec_wait_event.
+template <Kokkos::ExecutionSpace Exec>
+consteval bool test_has_exec_wait_event() {
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
+    if constexpr (std::same_as<Exec, Kokkos::DefaultExecutionSpace>) {
+        static_assert(Kokkos::Execution::Impl::has_exec_wait_event<Exec>);
+    } else
+#endif
+    {
+        static_assert(!Kokkos::Execution::Impl::has_exec_wait_event<Exec>);
+    }
+
+    return true;
+}
+static_assert(test_has_exec_wait_event<TEST_EXECUTION_SPACE>());
+
 //! @test Check the stream operator of @ref Kokkos::Execution::Impl::RecordEvent.
 TEST(RecordEvent, description) {
     const Kokkos::Execution::Impl::RecordEvent event{.dev_id = 42, .event_id = 1337};


### PR DESCRIPTION
So that they can share the same "with event" dependency implementation.