### PR TITLE
impl(event): many events to wait for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ target_sources(
             kokkos-execution/impl/event.hpp
             kokkos-execution/impl/HIP/dependency.hpp
             kokkos-execution/impl/HIP/event.hpp
+            kokkos-execution/impl/HPX/dependency.hpp
             kokkos-execution/impl/HPX/event.hpp
             kokkos-execution/impl/immovable.hpp
             kokkos-execution/impl/make_opstate.hpp

--- a/kokkos-execution/impl/Cuda/event.hpp
+++ b/kokkos-execution/impl/Cuda/event.hpp
@@ -49,10 +49,14 @@ struct Event<Kokkos::Cuda> {
     }
 };
 
-template <>
-void impl_wait(const Kokkos::Cuda& exec, const Event<Kokkos::Cuda>& event) {
-    KOKKOS_EXPECTS(bool(event.cuda_event()));
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamWaitEvent(exec.cuda_stream(), event.cuda_event()));
+template <Kokkos::ExecutionSpace... ExecFrom>
+requires(std::same_as<ExecFrom, Kokkos::Cuda> && ...)
+void impl_wait(const Kokkos::Cuda& exec, const Event<ExecFrom>&... events) {
+    auto do_impl_wait = [&exec](const auto& event) {
+        KOKKOS_EXPECTS(bool(event.cuda_event()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamWaitEvent(exec.cuda_stream(), event.cuda_event()));
+    };
+    (do_impl_wait(events), ...);
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/HIP/event.hpp
+++ b/kokkos-execution/impl/HIP/event.hpp
@@ -49,10 +49,14 @@ struct Event<Kokkos::HIP> {
     }
 };
 
-template <>
-void impl_wait(const Kokkos::HIP& exec, const Event<Kokkos::HIP>& event) {
-    KOKKOS_EXPECTS(bool(event.hip_event()));
-    KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamWaitEvent(exec.hip_stream(), event.hip_event()));
+template <Kokkos::ExecutionSpace... ExecFrom>
+requires(std::same_as<ExecFrom, Kokkos::HIP> && ...)
+void impl_wait(const Kokkos::HIP& exec, const Event<ExecFrom>&... events) {
+    auto do_impl_wait = [&exec](const auto& event) {
+        KOKKOS_EXPECTS(bool(event.hip_event()));
+        KOKKOS_IMPL_HIP_SAFE_CALL(hipStreamWaitEvent(exec.hip_stream(), event.hip_event()));
+    };
+    (do_impl_wait(events), ...);
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/HPX/dependency.hpp
+++ b/kokkos-execution/impl/HPX/dependency.hpp
@@ -1,0 +1,17 @@
+#ifndef KOKKOS_EXECUTION_IMPL_HPX_DEPENDENCY_HPP
+#define KOKKOS_EXECUTION_IMPL_HPX_DEPENDENCY_HPP
+
+/**
+ * @file
+ *
+ * Specialization of types from @ref kokkos-execution/impl/dependency.hpp for @c Kokkos::Experimental::HPX.
+ */
+
+namespace Kokkos::Execution::Impl {
+
+template <>
+struct HasExecWaitEvent<Kokkos::Experimental::HPX> : std::true_type { };
+
+} // namespace Kokkos::Execution::Impl
+
+#endif // KOKKOS_EXECUTION_IMPL_HPX_DEPENDENCY_HPP

--- a/kokkos-execution/impl/HPX/event.hpp
+++ b/kokkos-execution/impl/HPX/event.hpp
@@ -76,19 +76,33 @@ struct Event<Kokkos::Experimental::HPX> {
     }
 };
 
-//! Enqueue a call to @ref Event::wait into the underlying sender chain.
-template <>
-void impl_wait(const Kokkos::Experimental::HPX& exec, const Event<Kokkos::Experimental::HPX>& event) {
+template <Kokkos::ExecutionSpace... Exec>
+requires(std::same_as<Exec, Kokkos::Experimental::HPX> && ...)
+void impl_wait(const Event<Kokkos::Experimental::HPX>& event, const Event<Exec>&... events) {
+    KOKKOS_EXPECTS(event.m_sender.has_value() && (events.m_sender.has_value() && ...));
+
+    hpx::this_thread::experimental::sync_wait(
+        hpx::execution::experimental::when_all(std::move(*event.m_sender), std::move(*events.m_sender)...));
+
+    //! Mark the events as consumed.
+    event.m_sender = std::nullopt;
+    ((events.m_sender = std::nullopt), ...);
+}
+
+template <Kokkos::ExecutionSpace... ExecFrom>
+requires(std::same_as<ExecFrom, Kokkos::Experimental::HPX> && ...)
+void impl_wait(const Kokkos::Experimental::HPX& exec, const Event<ExecFrom>&... events) {
+    KOKKOS_EXPECTS((events.m_sender.has_value() && ...));
+
     auto& instance_data = exec.impl_get_instance_data();
 
     const std::scoped_lock<hpx::spinlock> lock(instance_data.m_sender_mutex);
 
     auto& sndr = instance_data.m_sender;
-    sndr = hpx::execution::experimental::unique_any_sender<>{
-        hpx::execution::experimental::when_all(std::move(sndr), std::move(*event.m_sender))};
+    sndr = hpx::execution::experimental::when_all(std::move(sndr), std::move(*events.m_sender)...);
 
-    //! Mark the event as consumed.
-    event.m_sender = std::nullopt;
+    //! Mark the events as consumed.
+    ((events.m_sender = std::nullopt), ...);
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/SYCL/event.hpp
+++ b/kokkos-execution/impl/SYCL/event.hpp
@@ -47,9 +47,10 @@ struct Event<Kokkos::SYCL> {
     }
 };
 
-template <>
-void impl_wait(const Kokkos::SYCL& exec, const Event<Kokkos::SYCL>& event) {
-    exec.sycl_queue().submit([&](sycl::handler& cgh) { cgh.depends_on(event.sycl_event()); });
+template <Kokkos::ExecutionSpace... ExecFrom>
+requires(std::same_as<ExecFrom, Kokkos::SYCL> && ...)
+void impl_wait(const Kokkos::SYCL& exec, const Event<ExecFrom>&... events) {
+    exec.sycl_queue().submit([&](sycl::handler& cgh) { (cgh.depends_on(events.sycl_event()), ...); });
 }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/impl/dependency.hpp
+++ b/kokkos-execution/impl/dependency.hpp
@@ -65,6 +65,9 @@ struct Dependency<Exec, Exec> {
 #if defined(KOKKOS_ENABLE_HIP)
 #    include "kokkos-execution/impl/HIP/dependency.hpp"
 #endif
+#if defined(KOKKOS_ENABLE_HPX)
+#    include "kokkos-execution/impl/HPX/dependency.hpp"
+#endif
 #if defined(KOKKOS_ENABLE_SYCL)
 #    include "kokkos-execution/impl/SYCL/dependency.hpp"
 #endif

--- a/kokkos-execution/impl/event.hpp
+++ b/kokkos-execution/impl/event.hpp
@@ -142,27 +142,32 @@ void record(Event<Exec>& event, const Exec& exec) {
     event.record(exec);
 }
 
-//! Wait for @p event to complete.
-template <Kokkos::ExecutionSpace Exec>
-void wait(const Event<Exec>& event) {
-    wait_event(event);
-    event.wait();
+template <Kokkos::ExecutionSpace... Exec>
+void impl_wait(const Event<Exec>&... events) {
+    (events.wait(), ...);
 }
 
-template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
-void impl_wait(const ExecTo&, const Event<ExecFrom>& event) {
-    event.wait();
+//! Wait for @p events to complete.
+template <Kokkos::ExecutionSpace... Exec>
+void wait(const Event<Exec>&... events) {
+    (wait_event(events), ...);
+    impl_wait(events...);
+}
+
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace... ExecFrom>
+void impl_wait(const ExecTo&, const Event<ExecFrom>&... events) {
+    (events.wait(), ...);
 }
 
 /**
- * @brief The operations enqueued from the calling thread into @p exec cannot start before the event @p event completes.
+ * @brief The operations enqueued from the calling thread into @p exec cannot start before the event @p events completes.
  *
  * @note Backends should specialize @ref impl_wait.
  */
-template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace ExecFrom>
-void wait(const ExecTo& exec, const Event<ExecFrom>& event) {
-    wait_event(exec, event);
-    impl_wait(exec, event);
+template <Kokkos::ExecutionSpace ExecTo, Kokkos::ExecutionSpace... ExecFrom>
+void wait(const ExecTo& exec, const Event<ExecFrom>&... events) {
+    (wait_event(exec, events), ...);
+    impl_wait(exec, events...);
 }
 
 template <Kokkos::ExecutionSpace Exec>

--- a/tests/execution_space/test_continues_on.cpp
+++ b/tests/execution_space/test_continues_on.cpp
@@ -391,6 +391,20 @@ TEST_F(ContinuesOnTest, transition_to_another_execution_space_instance_and_back_
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    } else if constexpr (
+        Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>
+        && std::same_as<host_execution_space, TEST_EXECUTION_SPACE>) {
+        ASSERT_THAT(
+            recorded_events,
+            ::testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_h, recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_h),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec, recorded_events.at(4)),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     } else {
         ASSERT_THAT(
             recorded_events,

--- a/tests/execution_space/test_on.cpp
+++ b/tests/execution_space/test_on.cpp
@@ -167,6 +167,20 @@ TEST_F(OnTest, many_execution_space_instances_of_different_type) {
                 MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
                 MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    } else if constexpr (
+        Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>
+        && std::same_as<host_execution_space, TEST_EXECUTION_SPACE>) {
+        ASSERT_THAT(
+            recorded_events,
+            testing::ElementsAre(
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_h, recorded_events.at(1)),
+                MATCHER_FOR_BEGIN_PFOR(exec_h, dispatch_label(exec_h, "then")),
+                MATCHER_FOR_RECORD_EVENT(exec_h),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec, recorded_events.at(4)),
+                MATCHER_FOR_BEGIN_PFOR(exec, dispatch_label(exec, "then")),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     } else {
         ASSERT_THAT(
             recorded_events,

--- a/tests/graph/test_continues_on.cpp
+++ b/tests/graph/test_continues_on.cpp
@@ -479,6 +479,26 @@ TEST_F(TEST_CATEGORY(ContinuesOnTest), transition_to_another_graph_scheduler_ins
                 MATCHER_FOR_GRAPH_SUBMIT(exec_h, recorded_events.at(2)),
                 MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(4)),
                 MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
+    } else if constexpr (
+        Kokkos::Execution::Impl::has_exec_wait_event<TEST_EXECUTION_SPACE>
+        && std::same_as<Kokkos::DefaultHostExecutionSpace, TEST_EXECUTION_SPACE>) {
+        ASSERT_THAT(
+            recorded_events,
+            testing::ElementsAre(
+                MATCHER_FOR_GRAPH_CREATE(device_handle),
+                MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(0), device_handle, nullptr),
+                MATCHER_FOR_GRAPH_CREATE(device_handle_h),
+                MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(2), device_handle_h, nullptr),
+                MATCHER_FOR_GRAPH_CREATE(device_handle),
+                MATCHER_FOR_GRAPH_ADDNODE(recorded_events.at(4), device_handle, nullptr),
+                MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(0)),
+                MATCHER_FOR_RECORD_EVENT(exec),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec_h, recorded_events.at(7)),
+                MATCHER_FOR_GRAPH_SUBMIT(exec_h, recorded_events.at(2)),
+                MATCHER_FOR_RECORD_EVENT(exec_h),
+                MATCHER_FOR_WAIT_EXEC_EVENT(exec, recorded_events.at(10)),
+                MATCHER_FOR_GRAPH_SUBMIT(exec, recorded_events.at(4)),
+                MATCHER_FOR_BEGIN_FENCE(exec, dispatch_label(exec, "sync_wait"))));
     } else {
         ASSERT_THAT(
             recorded_events,

--- a/tests/impl/test_event.cpp
+++ b/tests/impl/test_event.cpp
@@ -59,13 +59,19 @@ consteval bool test_has_exec_wait_event() {
 #if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
     if constexpr (std::same_as<Exec, Kokkos::DefaultExecutionSpace>) {
         static_assert(Kokkos::Execution::Impl::has_exec_wait_event<Exec>);
+        return true;
+    } else
+#endif
+#if defined(KOKKOS_ENABLE_HPX)
+        if constexpr (std::same_as<Exec, Kokkos::Experimental::HPX>) {
+        static_assert(Kokkos::Execution::Impl::has_exec_wait_event<Exec>);
+        return true;
     } else
 #endif
     {
         static_assert(!Kokkos::Execution::Impl::has_exec_wait_event<Exec>);
+        return true;
     }
-
-    return true;
 }
 static_assert(test_has_exec_wait_event<TEST_EXECUTION_SPACE>());
 
@@ -115,27 +121,6 @@ TEST_F(EventTest, record_but_dont_wait) {
     ASSERT_THAT(recorded_events, testing::SizeIs(2));
     ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec));
     ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_BEGIN_FENCE(exec, "some-label"));
-}
-
-//! @test Record an event and wait for it many times. It marks all wait events.
-TEST_F(EventTest, record_and_wait_many_times) {
-    const auto recorded_events = recorder_listener_t::record([this]() {
-        Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event;
-        Kokkos::Execution::Impl::record(event, exec);
-        Kokkos::Execution::Impl::wait(event);
-        Kokkos::Execution::Impl::wait(event);
-        Kokkos::Execution::Impl::wait(event);
-        Kokkos::Execution::Impl::wait(event);
-        Kokkos::Execution::Impl::wait(event);
-    });
-
-    ASSERT_THAT(recorded_events, ::testing::SizeIs(6));
-    ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec));
-    ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
-    ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
-    ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
-    ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
-    ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_WAIT_EVENT(recorded_events.at(0)));
 }
 
 //! @test Record an event and wait for it. Repeat the record/wait steps but reusing the same instance.
@@ -213,6 +198,27 @@ TEST_F(EventTest, wait_exec_event_for_same_type) {
     ASSERT_THAT(recorded_events, ::testing::SizeIs(3));
     ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec_A));
     ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(0)));
+}
+
+//! @test Check @ref Kokkos::Execution::Impl::wait when the underlying execution space type is the same and there are many events to wait for.
+TEST_F(EventTest, wait_exec_events_for_same_type) {
+    const auto [exec_A, exec_B] = Kokkos::Experimental::partition_space(exec, 1, 1);
+
+    const auto recorded_events = recorder_listener_t::record([&exec_A, &exec_B]() {
+        Kokkos::Execution::Impl::Event<TEST_EXECUTION_SPACE> event_A_0, event_A_1, event_A_2;
+        Kokkos::Execution::Impl::record(event_A_0, exec_A);
+        Kokkos::Execution::Impl::record(event_A_1, exec_A);
+        Kokkos::Execution::Impl::record(event_A_2, exec_A);
+        Kokkos::Execution::Impl::wait(exec_B, event_A_0, event_A_1, event_A_2);
+    });
+
+    ASSERT_THAT(recorded_events, ::testing::SizeIs(6));
+    ASSERT_THAT(recorded_events.at(0), MATCHER_FOR_RECORD_EVENT(exec_A));
+    ASSERT_THAT(recorded_events.at(1), MATCHER_FOR_RECORD_EVENT(exec_A));
+    ASSERT_THAT(recorded_events.at(2), MATCHER_FOR_RECORD_EVENT(exec_A));
+    ASSERT_THAT(recorded_events.at(3), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(0)));
+    ASSERT_THAT(recorded_events.at(4), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(1)));
+    ASSERT_THAT(recorded_events.at(5), MATCHER_FOR_WAIT_EXEC_EVENT(exec_B, recorded_events.at(2)));
 }
 
 //! @test Check @ref Kokkos::Execution::Impl::wait when the underlying execution space type is different.


### PR DESCRIPTION
This PR allows us to specialize the "wait for many events" action per backend.

The primary benefit is for HPX, for which we can write a nice `when_all`.

This PR also drops the test that was ensuring that `Impl::wait` could be called many times in a row. We do not need such a behavior, and it was broken for HPX (since the underlying senders are *moved*).