### PR TITLE
Impl: use concatenate in completion signatures

### DIFF
--- a/kokkos-execution/execution_space/continues_on.hpp
+++ b/kokkos-execution/execution_space/continues_on.hpp
@@ -121,7 +121,7 @@ template <stdexec::scheduler Schd, stdexec::sender Sndr>
 struct ContinuesOnSender {
     using sender_concept = stdexec::sender_tag;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender, Sndr)
 
     template <stdexec::receiver Rcvr>
     constexpr auto connect(Rcvr rcvr) && noexcept(

--- a/kokkos-execution/execution_space/parallel_for.hpp
+++ b/kokkos-execution/execution_space/parallel_for.hpp
@@ -43,7 +43,7 @@ struct ParallelForSender {
     closure_t clsr;
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, stdexec::set_error_t(std::exception_ptr))
+    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, Sndr, stdexec::set_error_t(std::exception_ptr))
 
     template <stdexec::receiver Rcvr>
     constexpr auto connect(Rcvr rcvr) && noexcept(noexcept(

--- a/kokkos-execution/execution_space/schedule_from.hpp
+++ b/kokkos-execution/execution_space/schedule_from.hpp
@@ -113,7 +113,7 @@ template <stdexec::sender Sndr>
 struct ScheduleFromSender {
     using sender_concept = stdexec::sender_tag;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender, Sndr)
 
     template <stdexec::receiver Rcvr>
     constexpr auto

--- a/kokkos-execution/execution_space/scoped_region.hpp
+++ b/kokkos-execution/execution_space/scoped_region.hpp
@@ -73,7 +73,7 @@ template <Kind kind, stdexec::sender Sndr>
 struct RegionSender {
     using sender_concept = stdexec::sender_tag;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(RegionSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(RegionSender, Sndr)
 
     template <typename Rcvr>
     using schd_t = Impl::completion_scheduler_of_t<stdexec::set_value_t, Sndr, stdexec::env_of_t<Rcvr>>;

--- a/kokkos-execution/graph/continues_on.hpp
+++ b/kokkos-execution/graph/continues_on.hpp
@@ -131,7 +131,7 @@ template <stdexec::scheduler Schd, stdexec::sender Sndr>
 struct ContinuesOnSender {
     using sender_concept = stdexec::sender_tag;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ContinuesOnSender, Sndr)
 
     template <typename Self, typename Rcvr>
     using connect_result_t =

--- a/kokkos-execution/graph/parallel_for.hpp
+++ b/kokkos-execution/graph/parallel_for.hpp
@@ -44,7 +44,7 @@ struct ParallelForSender {
 
     using closure_t = ParallelForClosure<Label, Functor, ExecPolicy>;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, stdexec::set_error_t(std::exception_ptr))
+    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, Sndr, stdexec::set_error_t(std::exception_ptr))
 
     KOKKOS_EXECUTION_GRAPH_OPERATION_STATE_CONNECT
 

--- a/kokkos-execution/graph/schedule_from.hpp
+++ b/kokkos-execution/graph/schedule_from.hpp
@@ -105,7 +105,7 @@ struct ScheduleFromSender {
 
     using execution_space = Exec;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(ScheduleFromSender, Sndr)
 
     template <typename Self, typename Rcvr>
     using connect_result_t = ScheduleFromOpState<execution_space, stdexec::__copy_cvref_t<Self, Sndr>, Rcvr>;

--- a/kokkos-execution/graph/then.hpp
+++ b/kokkos-execution/graph/then.hpp
@@ -53,7 +53,7 @@ struct ThenSender {
 
     using closure_t = ThenClosure<Exec, Functor>;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ThenSender, stdexec::set_error_t(std::exception_ptr))
+    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ThenSender, Sndr, stdexec::set_error_t(std::exception_ptr))
 
     KOKKOS_EXECUTION_GRAPH_OPERATION_STATE_CONNECT
 

--- a/kokkos-execution/impl/completion_signatures.hpp
+++ b/kokkos-execution/impl/completion_signatures.hpp
@@ -3,43 +3,47 @@
 
 #include "kokkos-execution/stdexec.hpp"
 
-#include "exec/completion_signatures.hpp"
-
 namespace Kokkos::Execution::Impl {
 
 /**
- * @brief Completion signatures of @c _sndr_type_.
- *
- * The @c stdexec::set_value_t() completion signature is added only if the child can complete successfully.
+ * @brief Concatenate @p Sndr completion signatures with @p ExtraSigs
+ *        if @p Sndr sends on the value channel; otherwise return @p Sndr
+ *        completion signatures unchanged.
  *
  * References:
  *  - https://github.com/NVIDIA/stdexec/commit/a0d95e90fc188f4f73328c4274551434edba3165
  *  - @cite P3557R3.
- */ // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define KOKKOS_EXECUTION_COMPL_SIGS_ADD(_sndr_type_, ...)                                                              \
-    template <::stdexec::__decays_to<_sndr_type_> Self, typename... Env>                                               \
+ */
+template <stdexec::sender Sndr, stdexec::__valid_completion_signatures ExtraSigs, typename... Env>
+consteval auto completion_signatures_add() {
+    using completions_t = stdexec::__completion_signatures_of_t<Sndr, Env...>;
+
+    if constexpr (stdexec::__sends<stdexec::set_value_t, Sndr, Env...>) {
+        return stdexec::__concat_completion_signatures(completions_t{}, ExtraSigs{});
+    } else {
+        return completions_t{};
+    }
+}
+
+template <stdexec::sender Sndr, stdexec::__valid_completion_signatures ExtraSigs, typename... Env>
+using completion_signatures_add_t = decltype(completion_signatures_add<Sndr, ExtraSigs, Env...>());
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define KOKKOS_EXECUTION_COMPL_SIGS_ADD(_decayed_self_type_, _sndr_type_, ...)                                         \
+    template <stdexec::__decays_to<_decayed_self_type_> Self, typename... Env>                                         \
     static consteval auto get_completion_signatures() {                                                                \
-        using child_completions_t =                                                                                    \
-            ::stdexec::__completion_signatures_of_t<::stdexec::__copy_cvref_t<Self, Sndr>, Env...>;                    \
-        constexpr auto success_completion_count =                                                                      \
-            ::stdexec::__msize_t<::stdexec::__detail::__count_of<::stdexec::set_value_t, child_completions_t>>::value; \
-        if constexpr (success_completion_count > 0) {                                                                  \
-            return experimental::execution::transform_completion_signatures(                                           \
-                child_completions_t{},                                                                                 \
-                experimental::execution::keep_completion<stdexec::set_value_t>(),                                      \
-                experimental::execution::ignore_completion(),                                                          \
-                experimental::execution::ignore_completion(),                                                          \
-                stdexec::completion_signatures<__VA_ARGS__>());                                                        \
-        } else {                                                                                                       \
-            return child_completions_t{};                                                                              \
-        }                                                                                                              \
+        return Kokkos::Execution::Impl::completion_signatures_add<                                                     \
+            stdexec::__copy_cvref_t<Self, _sndr_type_>,                                                                \
+            stdexec::completion_signatures<__VA_ARGS__>,                                                               \
+            Env...                                                                                                     \
+        >();                                                                                                           \
     }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define KOKKOS_EXECUTION_COMPL_SIGS_KEEP(_sndr_type_)                                                                  \
-    template <::stdexec::__decays_to<_sndr_type_> Self, typename... Env>                                               \
+#define KOKKOS_EXECUTION_COMPL_SIGS_KEEP(_decayed_self_type_, _sndr_type_)                                             \
+    template <stdexec::__decays_to<_decayed_self_type_> Self, typename... Env>                                         \
     static consteval auto get_completion_signatures() {                                                                \
-        return ::stdexec::__completion_signatures_of_t<::stdexec::__copy_cvref_t<Self, Sndr>, Env...>{};               \
+        return stdexec::__completion_signatures_of_t<stdexec::__copy_cvref_t<Self, _sndr_type_>, Env...>{};            \
     }
 
 } // namespace Kokkos::Execution::Impl

--- a/kokkos-execution/parallel_for.hpp
+++ b/kokkos-execution/parallel_for.hpp
@@ -73,7 +73,7 @@ struct ParallelForSender : stdexec::__tuple<parallel_for_t, ParallelForData<Labe
         : base_t{parallel_for_t{}, std::move(data), std::forward<Sndr>(sndr)} {
     }
 
-    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, stdexec::set_error_t(std::exception_ptr))
+    KOKKOS_EXECUTION_COMPL_SIGS_ADD(ParallelForSender, Sndr, stdexec::set_error_t(std::exception_ptr))
 
     template <stdexec::receiver Rcvr>
     constexpr auto connect(Rcvr) && = delete;

--- a/tests/impl/CMakeLists.txt
+++ b/tests/impl/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_one_test(NAME completion_signal)
+add_one_test(NAME completion_signatures)
 add_one_test(NAME dependency ADDITIONAL_LINK_LIBRARIES GTest::gmock)
 add_one_test(NAME env)
 add_one_test(NAME event ADDITIONAL_LINK_LIBRARIES GTest::gmock)

--- a/tests/impl/test_completion_signatures.cpp
+++ b/tests/impl/test_completion_signatures.cpp
@@ -1,0 +1,163 @@
+#include "gmock/gmock.h"
+
+#include "kokkos-execution/utils/ignore_warnings.hpp"
+PRAGMA_DIAGNOSTIC_PUSH
+KOKKOS_EXECUTION_STDEXEC_PRAGMA_DIAGNOSTIC_IGNORED
+#include "exec/single_thread_context.hpp"
+PRAGMA_DIAGNOSTIC_POP
+
+#include "kokkos-execution/execution_space.hpp"
+
+#include "tests/utils/execution_space_context.hpp"
+#include "tests/utils/functors/increment.hpp"
+#include "tests/utils/functors/throws_when_copied.hpp"
+
+/**
+ * @addtogroup unittests
+ *
+ * Completion signatures
+ * ---------------------
+ *
+ * This group of tests check our helpers for computing completion signatures from @ref kokkos-execution/impl/completion_signatures.hpp.
+ *
+ * The tests can be found in @ref tests/impl/test_completion_signatures.cpp.
+ */
+
+namespace Tests::Impl {
+
+using sndr_t =
+    decltype(stdexec::schedule(std::declval<experimental::execution::single_thread_context>().get_scheduler()) | stdexec::then([]() noexcept {
+             }));
+
+//! @test Check return type of @ref Kokkos::Execution::Impl::completion_signatures_add_t without added completion signature and an empty environment.
+consteval bool test_add_nothing_empty_env() {
+    static_assert(
+        stdexec::__mset_eq<
+            stdexec::__mset<stdexec::set_value_t()>,
+            Kokkos::Execution::Impl::completion_signatures_add_t<sndr_t, stdexec::completion_signatures<>, stdexec::env<>>
+        >);
+    return true;
+}
+static_assert(test_add_nothing_empty_env());
+
+//! @test Check return type of @ref Kokkos::Execution::Impl::completion_signatures_add_t with an added error completion signature and an empty environment.
+consteval bool test_add_error_empty_env() {
+    static_assert(stdexec::__mset_eq<
+                  stdexec::__mset<stdexec::set_value_t(), stdexec::set_error_t(float)>,
+                  Kokkos::Execution::Impl::completion_signatures_add_t<
+                      sndr_t,
+                      stdexec::completion_signatures<stdexec::set_error_t(float)>,
+                      stdexec::env<>
+                  >
+    >);
+    return true;
+}
+static_assert(test_add_error_empty_env());
+
+using env_with_stop_token_t = stdexec::prop<stdexec::get_stop_token_t, stdexec::inplace_stop_token>;
+
+//! @test Check return type of @ref Kokkos::Execution::Impl::completion_signatures_add_t without added completion signature and @ref env_with_stop_token_t.
+consteval bool test_add_nothing_stop_env() {
+    static_assert(stdexec::__mset_eq<
+                  stdexec::__mset<stdexec::set_value_t(), stdexec::set_stopped_t()>,
+                  Kokkos::Execution::Impl::completion_signatures_add_t<
+                      sndr_t,
+                      stdexec::completion_signatures<>,
+                      env_with_stop_token_t
+                  >
+    >);
+    return true;
+}
+static_assert(test_add_nothing_stop_env());
+
+//! @test Check return type of @ref Kokkos::Execution::Impl::completion_signatures_add_t with an added error completion signature and @ref env_with_stop_token_t.
+consteval bool test_add_error_stop_env() {
+    static_assert(stdexec::__mset_eq<
+                  stdexec::__mset<stdexec::set_value_t(), stdexec::set_stopped_t(), stdexec::set_error_t(float)>,
+                  Kokkos::Execution::Impl::completion_signatures_add_t<
+                      sndr_t,
+                      stdexec::completion_signatures<stdexec::set_error_t(float)>,
+                      env_with_stop_token_t
+                  >
+    >);
+
+    return true;
+}
+static_assert(test_add_error_stop_env());
+
+class CompletionSignaturesTest : public Tests::Utils::ExecutionSpaceContextTest<TEST_EXECUTION_SPACE> { };
+
+/**
+ * @test Check the propagation and addition of the value/error/stopped channels.
+ *
+ * This test implicitly exercices @ref KOKKOS_EXECUTION_COMPL_SIGS_ADD and @ref KOKKOS_EXECUTION_COMPL_SIGS_KEEP.
+ */
+TEST_F(CompletionSignaturesTest, parallel_for) {
+    const view_s_t data(Kokkos::view_alloc("data - shared space"));
+
+    experimental::execution::single_thread_context stc{};
+
+    const context_t esc{exec};
+
+    stdexec::inplace_stop_source source;
+
+    auto stc_then_continues_on_esc_sndr = stdexec::schedule(stc.get_scheduler()) | stdexec::then([]() noexcept { })
+                                        | stdexec::continues_on(esc.get_scheduler());
+
+    //! The stopped channel of the @c experimental::execution::single_thread_context is properly propagated.
+    static_assert(stdexec::__mset_eq<
+                  stdexec::__mset<stdexec::set_value_t(), stdexec::set_stopped_t()>,
+                  stdexec::__completion_signatures_of_t<decltype(stc_then_continues_on_esc_sndr), env_with_stop_token_t>
+    >);
+
+    auto stc_then_continues_on_esc_then_sndr =
+        std::move(stc_then_continues_on_esc_sndr) // NOLINT(performance-move-const-arg)
+        | stdexec::then(Tests::Utils::Functors::Increment<view_s_t, true, false>{.data = data});
+
+    //! The stopped channel is propagated, and the error channel is added.
+    static_assert(
+        stdexec::__mset_eq<
+            stdexec::__mset<stdexec::set_value_t(), stdexec::set_error_t(std::exception_ptr), stdexec::set_stopped_t()>,
+            stdexec::__completion_signatures_of_t<decltype(stc_then_continues_on_esc_then_sndr), env_with_stop_token_t>
+        >);
+
+    auto stc_then_continues_on_esc_then_then_sndr =
+        std::move(stc_then_continues_on_esc_then_sndr)
+        | stdexec::then(Tests::Utils::Functors::Increment<view_s_t, true, false>{.data = data});
+
+    //! The error channel was already added, it is added only once.
+    static_assert(
+        stdexec::__mset_eq<
+            stdexec::__mset<stdexec::set_value_t(), stdexec::set_error_t(std::exception_ptr), stdexec::set_stopped_t()>,
+            stdexec::__completion_signatures_of_t<
+                decltype(stc_then_continues_on_esc_then_then_sndr),
+                env_with_stop_token_t
+            >
+        >);
+
+    ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
+
+    ASSERT_FALSE(source.stop_requested());
+
+    KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP(stc_then_continues_on_esc_then_then_sndr)
+
+    const auto res_A = stdexec::sync_wait(
+        stc_then_continues_on_esc_then_then_sndr
+        | stdexec::write_env(stdexec::prop{stdexec::get_stop_token, source.get_token()}));
+
+    ASSERT_TRUE(res_A.has_value());
+
+    ASSERT_EQ(data(), 2);
+
+    source.request_stop();
+
+    const auto res_B = stdexec::sync_wait(
+        std::move(stc_then_continues_on_esc_then_then_sndr)
+        | stdexec::write_env(stdexec::prop{stdexec::get_stop_token, source.get_token()}));
+
+    ASSERT_FALSE(res_B.has_value());
+
+    ASSERT_EQ(data(), 2);
+}
+
+} // namespace Tests::Impl

--- a/tests/utils/check_rcvr_env.hpp
+++ b/tests/utils/check_rcvr_env.hpp
@@ -15,7 +15,7 @@ struct CheckRcvrEnvSender {
 
     Sndr sndr;
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvSender, Sndr)
 
     template <stdexec::__decays_to<CheckRcvrEnvSender> Self, stdexec::receiver Rcvr>
     [[nodiscard]]

--- a/tests/utils/check_rcvr_env_queryable_with.hpp
+++ b/tests/utils/check_rcvr_env_queryable_with.hpp
@@ -41,7 +41,7 @@ struct CheckRcvrEnvQueryableWithSender {
 
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvQueryableWithSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckRcvrEnvQueryableWithSender, Sndr)
 
     template <stdexec::__decays_to<CheckRcvrEnvQueryableWithSender> Self, stdexec::receiver Rcvr>
     [[nodiscard]]

--- a/tests/utils/check_scheduler_type.hpp
+++ b/tests/utils/check_scheduler_type.hpp
@@ -42,7 +42,7 @@ struct CheckSchedulerTypeSender {
 
     Sndr sndr; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 
-    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckSchedulerTypeSender)
+    KOKKOS_EXECUTION_COMPL_SIGS_KEEP(CheckSchedulerTypeSender, Sndr)
 
     template <stdexec::__decays_to<CheckSchedulerTypeSender> Self, stdexec::receiver Rcvr>
     [[nodiscard]]


### PR DESCRIPTION
This PR modifies our completion signatures helper. The goal is avoid discarding the error and stopped channels. The proposed solution uses concatenate to avoid duplication.

Extracted from:
- #238 