### PR TITLE
tests(graph): `when_all` branches observe dependencies when mixed with other schedulers

### DIFF
--- a/tests/graph/test_when_all.cpp
+++ b/tests/graph/test_when_all.cpp
@@ -302,28 +302,40 @@ TEST_F(TEST_CATEGORY(WhenAllTest), three_branches) {
  * @c experimental::execution::single_thread_context.
  */
 TEST_F(TEST_CATEGORY(WhenAllTest), three_branches_starting_on_single_thread_context) {
-    const view_s_t data(Kokkos::view_alloc(exec, "data - shared space"));
+    const Kokkos::View<value_t[3], Kokkos::SharedSpace> data_per_branch(Kokkos::view_alloc("data - shared space"));
 
     experimental::execution::single_thread_context stc_a{}, stc_b{}, stc_c{};
 
     const context_t gctx{exec};
 
-    auto branch_a = stdexec::schedule(stc_a.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data)
-                  | stdexec::continues_on(gctx.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data);
-    auto branch_b = stdexec::schedule(stc_b.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data)
-                  | stdexec::continues_on(gctx.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data);
-    auto branch_c = stdexec::schedule(stc_c.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data)
-                  | stdexec::continues_on(gctx.get_scheduler()) | THEN_INCREMENT_ATOMIC(System, data);
+    using functor_h_t = Tests::Utils::Functors::LoadCheckAdd<value_t, false>;
+    using functor_d_t = Tests::Utils::Functors::LoadCheckAdd<value_t, on_device>;
 
-    auto sndr = stdexec::when_all(std::move(branch_a), std::move(branch_b), std::move(branch_c));
+    auto branch_a = stdexec::schedule(stc_a.get_scheduler())
+                  | stdexec::then(functor_h_t{.prev = 0, .value = 2, .data = &data_per_branch(0)})
+                  | stdexec::continues_on(gctx.get_scheduler())
+                  | stdexec::then(functor_d_t{.prev = 2, .value = 3, .data = &data_per_branch(0)});
+    auto branch_b = stdexec::schedule(stc_b.get_scheduler())
+                  | stdexec::then(functor_h_t{.prev = 0, .value = 3, .data = &data_per_branch(1)})
+                  | stdexec::continues_on(gctx.get_scheduler())
+                  | stdexec::then(functor_d_t{.prev = 3, .value = 4, .data = &data_per_branch(1)});
+    auto branch_c = stdexec::schedule(stc_c.get_scheduler())
+                  | stdexec::then(functor_h_t{.prev = 0, .value = 4, .data = &data_per_branch(2)})
+                  | stdexec::continues_on(gctx.get_scheduler())
+                  | stdexec::then(functor_d_t{.prev = 4, .value = 5, .data = &data_per_branch(2)});
 
-    ASSERT_EQ(data(), 0) << "Eager execution is not allowed.";
+    auto sndr = stdexec::when_all(
+        std::move(branch_a), std::move(branch_b), std::move(branch_c)); // NOLINT(performance-move-const-arg)
+
+    ASSERT_THAT(Tests::Utils::span_from(data_per_branch), testing::Each(testing::Eq(0)))
+        << "Eager execution is not " "allowed.";
 
     KOKKOS_EXECUTION_THREADS_THROWS_ON_SYNC_WAIT_ASSERT_AND_SKIP(sndr)
 
     KOKKOS_EXECUTION_TEST_UTILS_GRAPH_FENCE(exec);
 
-    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
+    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(
+        std::move(sndr)); // NOLINT(performance-move-const-arg)
 
     ASSERT_THAT(
         recorded_events,
@@ -340,7 +352,7 @@ TEST_F(TEST_CATEGORY(WhenAllTest), three_branches_starting_on_single_thread_cont
             MATCHER_FOR_GRAPH_SUBMIT(TEST_EXECUTION_SPACE{}, recorded_events.at(0)),
             MATCHER_FOR_BEGIN_FENCE(TEST_EXECUTION_SPACE{}, dispatch_label(TEST_EXECUTION_SPACE{}, "after dispatch"))));
 
-    ASSERT_EQ(data(), 6);
+    ASSERT_THAT(Tests::Utils::span_from(data_per_branch), testing::ElementsAre(5, 7, 9));
 }
 
 /**
@@ -369,7 +381,8 @@ TEST_F(TEST_CATEGORY(WhenAllTest), three_branches_some_starting_on_single_thread
     auto branch_c = stdexec::schedule(gctx.get_scheduler())
                   | stdexec::then(functor_d_t{.prev = 0, .value = 4, .data = &data_per_branch(2)});
 
-    auto sndr = stdexec::when_all(std::move(branch_a), std::move(branch_b), std::move(branch_c));
+    auto sndr = stdexec::when_all(
+        std::move(branch_a), std::move(branch_b), std::move(branch_c)); // NOLINT(performance-move-const-arg)
 
     ASSERT_THAT(Tests::Utils::span_from(data_per_branch), testing::Each(testing::Eq(0)))
         << "Eager execution is not " "allowed.";
@@ -378,7 +391,8 @@ TEST_F(TEST_CATEGORY(WhenAllTest), three_branches_some_starting_on_single_thread
 
     KOKKOS_EXECUTION_TEST_UTILS_GRAPH_FENCE(exec);
 
-    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(std::move(sndr));
+    const auto recorded_events = Tests::Utils::record_sync_wait<recorder_listener_t>(
+        std::move(sndr)); // NOLINT(performance-move-const-arg)
 
     ASSERT_THAT(
         recorded_events,


### PR DESCRIPTION
The previous test would not be able to detect preceding constraint violations.